### PR TITLE
feat(cli): add `clawhive logs` command to tail the latest log file

### DIFF
--- a/crates/clawhive-cli/src/main.rs
+++ b/crates/clawhive-cli/src/main.rs
@@ -74,6 +74,17 @@ enum Commands {
         #[arg(long)]
         no_security: bool,
     },
+    #[command(about = "Start clawhive as a background daemon (alias for `start -d`)")]
+    Up {
+        #[arg(long, default_value = "8848", help = "HTTP API server port")]
+        port: u16,
+        /// Override security mode (overrides agent config)
+        #[arg(long, value_name = "MODE")]
+        security: Option<SecurityMode>,
+        /// Shorthand for --security off
+        #[arg(long)]
+        no_security: bool,
+    },
     #[command(about = "Stop a running clawhive process")]
     Stop,
     #[command(about = "Restart clawhive (stop + start)")]
@@ -423,6 +434,15 @@ async fn main() -> Result<()> {
             } else {
                 start_bot(&cli.config_root, tui, port, security_override).await?;
             }
+        }
+        Commands::Up {
+            port,
+            security,
+            no_security,
+        } => {
+            ensure_skeleton_config(&cli.config_root, port)?;
+            let security_override = resolve_security_override(security, no_security);
+            daemonize(&cli.config_root, false, port, security_override)?;
         }
         Commands::Stop => {
             stop_process(&cli.config_root)?;


### PR DESCRIPTION
## Summary

- Adds a new `clawhive logs` subcommand that automatically finds the latest daily rolling log file and runs `tail -f` on it
- Supports a `-n / --lines` flag to control how many historical lines are shown before following (default: 50)
- Suppresses stderr tracing output while the command runs to avoid corrupting the terminal

## Usage

\`\`\`bash
# Default: show last 50 lines then follow
clawhive logs

# Show last 200 lines before following
clawhive logs -n 200
\`\`\`

## How it works

Log files are produced by `tracing_appender::rolling::daily` and named `clawhive.log.YYYY-MM-DD`. The command reads the `<config-root>/logs/` directory, sorts files lexicographically (which naturally orders them by date), picks the last one (newest), and execs `tail -f` on it.

## Test plan

- [ ] `clawhive logs` streams the latest log file and follows new output
- [ ] `clawhive logs -n 100` shows 100 lines of history before following
- [ ] Friendly error message when the log directory does not exist yet
- [ ] `clawhive logs --help` shows correct usage text