### PR TITLE
docs: reorganize README - installation first, technical details collapsed

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,115 +9,129 @@ English | [中文](README_CN.md)
 
 An open-source, Rust-native alternative to [OpenClaw](https://github.com/openclaw/openclaw) — deploy your own AI agents across Telegram, Discord, Slack, WhatsApp, iMessage, and more with a single binary.
 
-## Overview
+**One binary, ~14 MB, zero runtime dependencies.** No Node.js, no npm, no Docker — just download, configure, and run.
 
-clawhive delivers the personal AI assistant experience of OpenClaw, rebuilt from the ground up in Rust. Where OpenClaw runs on Node.js with 430k+ lines of code, clawhive ships as a **single static binary with zero runtime dependencies** — no Node.js, no npm, no Docker required. Just download, configure, and run.
+## Installation
 
-**Why clawhive over OpenClaw?**
-
-- **Tiny footprint** — One binary, ~14 MB. Runs on a Raspberry Pi, a VPS, or a Mac Mini with minimal resource usage. No garbage collection pauses, predictable memory.
-- **Security by design** — Two-layer security model enforced from day one: a non-bypassable hard baseline blocks SSRF, dangerous commands, and sensitive file access system-wide. External skills must declare permissions explicitly — no ambient authority.
-- **Bounded execution** — Agents have enforced token budgets, timeout limits, and sub-agent recursion depth. No runaway loops, no surprise bills.
-- **Web + CLI setup** — Browser-based setup wizard or interactive CLI. Get your first agent running in under 2 minutes.
-
-## 🔐 Security First
-
-clawhive implements a **two-layer security architecture** that provides defense-in-depth for AI agent tool execution:
-
-### Hard Baseline (Always Enforced)
-
-These security constraints are **non-negotiable** and apply to ALL tool executions, regardless of trust level:
-
-| Protection | What It Blocks |
-|------------|----------------|
-| **SSRF Prevention** | Private networks (10.x, 172.16-31.x, 192.168.x), loopback, cloud metadata endpoints (169.254.169.254) |
-| **Sensitive Path Protection** | Writes to `~/.ssh/`, `~/.gnupg/`, `~/.aws/`, `/etc/`, system directories |
-| **Private Key Shield** | Reads of `~/.ssh/id_*`, `~/.gnupg/private-keys`, cloud credentials |
-| **Dangerous Command Block** | `rm -rf /`, fork bombs, disk wipes, curl-pipe-to-shell patterns |
-| **Resource Limits** | 30s timeout, 1MB output cap, 5 concurrent executions |
-
-### Origin-Based Trust Model
-
-Tools are classified by origin, determining their permission requirements:
-
-| Origin | Trust Level | Permission Checks |
-|--------|-------------|-------------------|
-| **Builtin** | Trusted | Hard baseline only (no permission declarations needed) |
-| **External** | Sandboxed | Must declare all permissions in SKILL.md frontmatter |
-
-### Skill Permission Declaration
-
-External skills must explicitly declare their required permissions in SKILL.md:
-
-```yaml
----
-name: weather-skill
-description: Get weather forecasts
-permissions:
-  network:
-    allow:
-      - "api.openweathermap.org:443"
-      - "api.weatherapi.com:443"
-  fs:
-    read:
-      - "${WORKSPACE}/**"
-    write:
-      - "${WORKSPACE}/cache/**"
-  exec:
-    - curl
-    - jq
-  env:
-    - WEATHER_API_KEY
----
+```bash
+curl -fsSL https://raw.githubusercontent.com/longzhi/clawhive/main/install.sh | bash
 ```
 
-**Any access outside declared permissions is denied at runtime.**
+Auto-detects OS/architecture, downloads latest release, installs binary and skills to `~/.clawhive/`.
 
-### Security Philosophy
+After installation, restart your shell or run:
 
-1. **Deny by default** — External skills have no permissions unless explicitly declared
-2. **Hard baseline is non-bypassable** — Even misconfigured permissions can't override it
-3. **Honest documentation** — We only claim what's implemented, not roadmap intent
-4. **Defense in depth** — Multiple layers prevent single-point failures
+```bash
+source ~/.zshrc  # or ~/.bashrc
+```
 
-## Technical Differentiators (vs OpenClaw)
+Or download manually from [GitHub Releases](https://github.com/longzhi/clawhive/releases).
 
-| Aspect | clawhive | OpenClaw |
-|--------|----------|----------|
-| **Runtime** | Pure Rust binary, embedded SQLite | Node.js runtime |
-| **Security Model** | Two-layer policy (hard baseline + origin trust) | Tool allowlist |
-| **Permission System** | Declarative SKILL.md permissions | Runtime policy |
-| **Memory** | Markdown-native (MEMORY.md canonical) | Markdown-native (MEMORY.md + memory/*.md) |
-| **Integration Surface** | Multi-channel (Telegram, Discord, Slack, WhatsApp, iMessage, CLI) | Broad connectors |
-| **Dependency** | Single binary, no runtime deps | Node.js + npm |
+## Setup
 
-### Key Architectural Choices
+Configure providers, agents, and channels using either method:
 
-- **Rust workspace with embedded SQLite** (`rusqlite` + bundled): zero runtime dependencies in production
-- **Markdown-first memory**: `MEMORY.md` and daily files are canonical; SQLite index is rebuildable
-- **Permission-as-code**: Skills declare permissions in YAML frontmatter, enforced at runtime
-- **Bounded execution**: Token-bucket rate limits, sub-agent recursion limits, timeouts
+**Option A: Web Setup Wizard** — Start the server and open the browser-based wizard:
+
+```bash
+clawhive start
+# Open http://localhost:3000/setup in your browser
+```
+
+**Option B: CLI Setup Wizard** — Run the interactive terminal wizard:
+
+```bash
+clawhive setup
+```
+
+## Usage
+
+```bash
+# Setup / config
+clawhive setup
+clawhive validate
+
+# Chat mode (local REPL)
+clawhive chat
+
+# Service lifecycle
+clawhive up                  # start as background daemon (alias for start -d)
+clawhive start               # start in foreground
+clawhive start --daemon      # start as background daemon (alias: -d)
+clawhive restart
+clawhive stop
+
+# Dashboard mode (observability TUI)
+clawhive dashboard
+
+# Code mode (developer TUI)
+clawhive code
+
+# Agents / sessions
+clawhive agent list
+clawhive agent show clawhive-main
+clawhive session reset <session_key>
+
+# Schedules / tasks
+clawhive schedule list
+clawhive schedule run <schedule_id>
+clawhive task trigger clawhive-main "summarize today's work"
+
+# Logs
+clawhive logs
+
+# Auth
+clawhive auth status
+clawhive auth login openai
+```
+
+## CLI Commands
+
+| Command | Description |
+|---------|-------------|
+| `setup` | Interactive configuration wizard |
+| `up` | Start as background daemon (alias for `start -d`) |
+| `start [--tui] [--daemon]` | Start all configured channel bots and HTTP API server |
+| `stop` | Stop a running clawhive process |
+| `restart` | Restart clawhive (stop + start) |
+| `chat [--agent <id>]` | Local REPL for testing |
+| `validate` | Validate YAML configuration |
+| `consolidate` | Run memory consolidation manually |
+| `logs` | Tail the latest log file |
+| `agent list\|show\|enable\|disable` | Agent management |
+| `skill list\|show\|analyze\|install` | Skill management |
+| `session reset <key>` | Reset a session |
+| `schedule list\|run\|enable\|disable\|history` | Scheduled task management |
+| `wait list` | List background wait tasks |
+| `task trigger <agent> <task>` | Send a one-off task to an agent |
+| `auth login\|status` | OAuth authentication management |
+
+## Why clawhive?
+
+- **Tiny footprint** — One binary, ~14 MB. Runs on a Raspberry Pi, a VPS, or a Mac Mini with minimal resource usage.
+- **Security by design** — Two-layer security model: non-bypassable hard baseline + origin-based trust. External skills must declare permissions explicitly.
+- **Bounded execution** — Enforced token budgets, timeout limits, and sub-agent recursion depth. No runaway loops, no surprise bills.
+- **Web + CLI setup** — Browser-based setup wizard or interactive CLI. Get your first agent running in under 2 minutes.
 
 ## Features
 
 - Multi-agent orchestration with per-agent personas, model routing, and memory policy controls
-- Three-layer memory system: Session JSONL (working memory) → Daily files (short-term) → MEMORY.md (long-term)
-- Hybrid search: sqlite-vec vector similarity (70%) + FTS5 BM25 (30%) over memory chunks
-- Hippocampus consolidation: periodic LLM-driven synthesis of daily observations into long-term memory
+- Three-layer memory system: Session JSONL → Daily files → MEMORY.md (long-term)
+- Hybrid search: sqlite-vec vector similarity + FTS5 BM25 over memory chunks
+- Hippocampus consolidation: periodic LLM-driven synthesis into long-term memory
 - Channel adapters: Telegram, Discord, Slack, WhatsApp, iMessage (multi-bot, multi-connector)
-- ReAct reasoning loop with repeat guard
-- Sub-agent spawning with depth limits and timeout
-- Skill system (SKILL.md with frontmatter + prompt injection)
+- ReAct reasoning loop with repeat guard and sub-agent spawning
+- Skill system (SKILL.md with frontmatter + permission declarations)
 - Token-bucket rate limiting per user
 - LLM provider abstraction with retry + exponential backoff (Anthropic, OpenAI, Gemini, DeepSeek, Groq, Ollama, OpenRouter, Together, Fireworks, and any OpenAI-compatible endpoint)
-- Real-time TUI dashboard (sessions, events, agent status)
-- YAML-driven configuration (agents, providers, routing)
+- Real-time TUI dashboard and YAML-driven configuration
 
 ## Architecture
 
 ![clawhive architecture](assets/architecture.png)
 
-## Project Structure
+<details>
+<summary><strong>Project Structure</strong></summary>
 
 ```
 crates/
@@ -148,186 +162,112 @@ crates/
 └── logs/                # Log files
 ```
 
-## Installation
+</details>
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/longzhi/clawhive/main/install.sh | bash
+<details>
+<summary><strong>Security Model</strong></summary>
+
+clawhive implements a **two-layer security architecture** for defense-in-depth:
+
+**Hard Baseline (Always Enforced)**
+
+| Protection | What It Blocks |
+|------------|----------------|
+| **SSRF Prevention** | Private networks (10.x, 172.16-31.x, 192.168.x), loopback, cloud metadata endpoints |
+| **Sensitive Path Protection** | Writes to `~/.ssh/`, `~/.gnupg/`, `~/.aws/`, `/etc/`, system directories |
+| **Private Key Shield** | Reads of `~/.ssh/id_*`, `~/.gnupg/private-keys`, cloud credentials |
+| **Dangerous Command Block** | `rm -rf /`, fork bombs, disk wipes, curl-pipe-to-shell patterns |
+| **Resource Limits** | 30s timeout, 1MB output cap, 5 concurrent executions |
+
+**Origin-Based Trust Model**
+
+| Origin | Trust Level | Permission Checks |
+|--------|-------------|-------------------|
+| **Builtin** | Trusted | Hard baseline only |
+| **External** | Sandboxed | Must declare all permissions in SKILL.md frontmatter |
+
+External skills declare permissions in SKILL.md:
+
+```yaml
+---
+name: weather-skill
+permissions:
+  network:
+    allow: ["api.openweathermap.org:443"]
+  fs:
+    read: ["${WORKSPACE}/**"]
+  exec: [curl, jq]
+  env: [WEATHER_API_KEY]
+---
 ```
 
-Auto-detects OS/architecture, downloads latest release, installs binary and skills to `~/.clawhive/`.
+Any access outside declared permissions is denied at runtime.
 
-After installation, restart your shell or run:
+</details>
 
-```bash
-source ~/.zshrc  # or ~/.bashrc
-```
+<details>
+<summary><strong>Memory System</strong></summary>
 
-Or download manually from [GitHub Releases](https://github.com/longzhi/clawhive/releases).
+Three-layer architecture inspired by neuroscience:
 
-### Setup
+1. **Session JSONL** (`sessions/<id>.jsonl`) — append-only conversation log, typed entries. Used for session recovery and audit trail.
+2. **Daily Files** (`memory/YYYY-MM-DD.md`) — daily observations written by LLM during conversations.
+3. **MEMORY.md** — curated long-term knowledge. Updated by hippocampus consolidation (LLM synthesis of recent daily files).
+4. **SQLite Search Index** — sqlite-vec + FTS5. Hybrid search: vector similarity × 0.7 + BM25 × 0.3.
 
-After installation, configure providers, agents, and channels using either method:
+Note: JSONL files are NOT indexed. Only Markdown memory files participate in search.
 
-**Option A: Web Setup Wizard** — Start the server and open the browser-based wizard:
+</details>
 
-```bash
-clawhive start
-# Open http://localhost:3000/setup in your browser
-```
+<details>
+<summary><strong>Technical Comparison (vs OpenClaw)</strong></summary>
 
-**Option B: CLI Setup Wizard** — Run the interactive terminal wizard:
+| Aspect | clawhive | OpenClaw |
+|--------|----------|----------|
+| **Runtime** | Pure Rust binary, embedded SQLite | Node.js runtime |
+| **Security Model** | Two-layer policy (hard baseline + origin trust) | Tool allowlist |
+| **Permission System** | Declarative SKILL.md permissions | Runtime policy |
+| **Memory** | Markdown-native (MEMORY.md canonical) | Markdown-native (MEMORY.md + memory/*.md) |
+| **Integration Surface** | Multi-channel (Telegram, Discord, Slack, WhatsApp, iMessage, CLI) | Broad connectors |
+| **Dependency** | Single binary, no runtime deps | Node.js + npm |
 
-```bash
-clawhive setup
-```
+</details>
 
-### Run
-
-```bash
-# Setup / config
-clawhive setup
-clawhive validate
-
-# Chat mode (local REPL)
-clawhive chat
-
-# Service lifecycle
-clawhive start
-clawhive start --daemon  # alias: -d
-clawhive restart
-clawhive restart --daemon  # alias: -d
-clawhive stop
-
-# Dashboard mode (observability TUI)
-clawhive dashboard
-clawhive dashboard --port 3000
-
-# Code mode (developer TUI)
-clawhive code
-clawhive code --port 3000
-
-# Agents / sessions
-clawhive agent list
-clawhive agent show clawhive-main
-clawhive session reset <session_key>
-
-# Schedules / tasks
-clawhive schedule list
-clawhive schedule run <schedule_id>
-clawhive task trigger clawhive-main "summarize today's work"
-
-# Auth
-clawhive auth status
-clawhive auth login openai
-```
-
-## Quick Start (Developers)
-
-Prerequisites: Rust 1.92+
-
-```bash
-# Clone and build
-git clone https://github.com/longzhi/clawhive.git
-cd clawhive
-cargo build --workspace
-
-# Interactive setup (configure providers, agents, channels)
-cargo run -- setup
-
-# Chat mode (local REPL)
-cargo run -- chat
-
-# Start all configured channel bots
-cargo run -- start
-
-# Start as background daemon
-cargo run -- start --daemon  # alias: -d
-
-# Restart / stop
-cargo run -- restart
-cargo run -- restart --daemon
-cargo run -- stop
-
-# Dashboard mode (observability TUI)
-cargo run -- dashboard
-cargo run -- dashboard --port 3000
-
-# Coding agent mode (attach local TUI channel to running gateway)
-cargo run -- code
-cargo run -- code --port 3000
-```
-
-## Developer Workflow
-
-Use local quality gates before pushing:
-
-```bash
-# One-time: install repo-managed git hooks
-just install-hooks
-
-# Run all CI-equivalent checks locally
-just check
-
-# Release flow: check -> push main -> replace tag and push tag
-just release v0.1.0-alpha.15
-```
-
-If you don't use `just`, use scripts directly:
-
-```bash
-bash scripts/install-git-hooks.sh
-bash scripts/check.sh
-bash scripts/release.sh v0.1.0-alpha.15
-```
-
-`just check` runs:
-
-1. `cargo fmt --all -- --check`
-2. `cargo clippy --workspace --all-targets -- -D warnings`
-3. `cargo test --workspace`
-
-## Configuration
+<details>
+<summary><strong>Configuration</strong></summary>
 
 Configuration is managed through `clawhive setup`, which interactively generates YAML files under `~/.clawhive/config/`:
 
 - `main.yaml` — app name, runtime settings, feature flags, channel config
-- `agents.d/<agent_id>.yaml` — agent identity (name, emoji), model policy (primary + fallbacks), tool policy, memory policy
-- `providers.d/<provider>.yaml` — provider type, API base URL, authentication (API key or OAuth)
+- `agents.d/<agent_id>.yaml` — agent identity, model policy, tool policy, memory policy
+- `providers.d/<provider>.yaml` — provider type, API base URL, authentication
 - `routing.yaml` — default agent ID, channel-to-agent routing bindings
 
 Supported providers: Anthropic, OpenAI, Gemini, DeepSeek, Groq, Ollama, OpenRouter, Together, Fireworks, and any OpenAI-compatible endpoint.
 
-## Memory System
-
-clawhive uses a three-layer memory architecture inspired by neuroscience:
-
-1. **Session JSONL** (`sessions/<id>.jsonl`) — append-only conversation log, typed entries (message, tool_call, tool_result, compaction, model_change). Used for session recovery and audit trail.
-2. **Daily Files** (`memory/YYYY-MM-DD.md`) — daily observations written by LLM during conversations. Fallback summary generated if LLM didn't write anything in a session.
-3. **MEMORY.md** — curated long-term knowledge. Updated by hippocampus consolidation (LLM synthesis of recent daily files) and direct LLM writes.
-4. **SQLite Search Index** — sqlite-vec 0.1.6 + FTS5. Markdown files chunked (~400 tokens, 80 token overlap), embedded, indexed. Hybrid search: vector similarity × 0.7 + BM25 × 0.3.
-
-Note: JSONL files are NOT indexed (too noisy). Only Markdown memory files participate in search.
-
-## CLI Commands
-
-| Command | Description |
-|---------|-------------|
-| `setup` | Interactive configuration wizard |
-| `start [--tui] [--daemon]` | Start all configured channel bots and HTTP API server |
-| `stop` | Stop a running clawhive process |
-| `restart` | Restart clawhive (stop + start) |
-| `chat [--agent <id>]` | Local REPL for testing |
-| `validate` | Validate YAML configuration |
-| `consolidate` | Run memory consolidation manually |
-| `agent list\|show\|enable\|disable` | Agent management |
-| `skill list\|show\|analyze\|install` | Skill management |
-| `session reset <key>` | Reset a session |
-| `schedule list\|run\|enable\|disable\|history` | Scheduled task management |
-| `wait list` | List background wait tasks |
-| `task trigger <agent> <task>` | Send a one-off task to an agent |
-| `auth login\|status` | OAuth authentication management |
+</details>
 
 ## Development
+
+<details>
+<summary><strong>Quick Start (Developers)</strong></summary>
+
+Prerequisites: Rust 1.92+
+
+```bash
+git clone https://github.com/longzhi/clawhive.git
+cd clawhive
+cargo build --workspace
+
+cargo run -- setup       # Interactive setup
+cargo run -- chat        # Chat mode (local REPL)
+cargo run -- start       # Start all channel bots
+cargo run -- start -d    # Start as background daemon
+cargo run -- dashboard   # Dashboard mode
+cargo run -- code        # Coding agent mode
+```
+
+</details>
 
 ```bash
 # Run all tests
@@ -338,6 +278,12 @@ cargo clippy --workspace --all-targets -- -D warnings
 
 # Format
 cargo fmt --all
+
+# Run all CI-equivalent checks locally
+just check
+
+# Release
+just release v0.1.0-alpha.15
 ```
 
 ## Tech Stack

--- a/README_CN.md
+++ b/README_CN.md
@@ -9,115 +9,129 @@
 
 用 Rust 从零构建的开源 AI Agent 平台——一个二进制文件，部署到 Telegram、Discord、Slack、WhatsApp、iMessage 等多个渠道。
 
-## 概述
+**单文件约 14MB，零运行时依赖。** 不需要 Node.js，不需要 npm，不需要 Docker——下载、配置、运行。
 
-clawhive 是 [OpenClaw](https://github.com/openclaw/openclaw) 的 Rust 原生替代方案。OpenClaw 基于 Node.js、43 万行代码；clawhive 编译为**单个静态二进制文件，零运行时依赖**——不需要 Node.js，不需要 npm，不需要 Docker。下载、配置、运行，就这么简单。
+## 安装
 
-**为什么选择 clawhive？**
-
-- **极致轻量** — 单文件约 14MB，运行时内存占用约 48MB。树莓派、VPS、Mac Mini 都能跑。没有 GC 停顿，内存可预测。
-- **安全先行** — 从第一天就内置两层安全模型：不可绕过的硬基线拦截 SSRF、危险命令和敏感文件访问；第三方 Skill 必须显式声明权限，没有隐式授权。
-- **有限执行** — Agent 有强制的 Token 预算、超时限制和子 Agent 递归深度限制。不会有无限循环，不会有天价账单。
-- **Web + CLI 配置** — 浏览器向导或交互式 CLI，2 分钟内跑起你的第一个 Agent。
-
-## 🔐 安全优先
-
-clawhive 实现了**两层安全架构**，为 AI Agent 的工具执行提供纵深防御：
-
-### 硬基线（始终强制）
-
-以下安全约束**不可协商**，适用于所有工具执行，无论信任级别：
-
-| 防护类型 | 拦截内容 |
-|---------|---------|
-| **SSRF 防护** | 私有网络（10.x、172.16-31.x、192.168.x）、回环地址、云元数据端点（169.254.169.254） |
-| **敏感路径保护** | 写入 `~/.ssh/`、`~/.gnupg/`、`~/.aws/`、`/etc/` 等系统目录 |
-| **私钥防护** | 读取 `~/.ssh/id_*`、`~/.gnupg/private-keys`、云凭证 |
-| **危险命令拦截** | `rm -rf /`、fork bomb、磁盘擦除、curl 管道到 shell |
-| **资源限制** | 30 秒超时、1MB 输出上限、5 个并发执行 |
-
-### 基于来源的信任模型
-
-工具按来源分类，决定其权限要求：
-
-| 来源 | 信任级别 | 权限检查 |
-|------|---------|---------|
-| **内置** | 受信任 | 仅硬基线（无需权限声明） |
-| **外部** | 沙箱化 | 必须在 SKILL.md frontmatter 中声明所有权限 |
-
-### Skill 权限声明
-
-外部 Skill 必须在 SKILL.md 中显式声明所需权限：
-
-```yaml
----
-name: weather-skill
-description: Get weather forecasts
-permissions:
-  network:
-    allow:
-      - "api.openweathermap.org:443"
-      - "api.weatherapi.com:443"
-  fs:
-    read:
-      - "${WORKSPACE}/**"
-    write:
-      - "${WORKSPACE}/cache/**"
-  exec:
-    - curl
-    - jq
-  env:
-    - WEATHER_API_KEY
----
+```bash
+curl -fsSL https://raw.githubusercontent.com/longzhi/clawhive/main/install.sh | bash
 ```
 
-**未声明的权限在运行时一律拒绝。**
+自动检测操作系统和架构，下载最新版本，将二进制文件和 Skill 安装到 `~/.clawhive/`。
 
-### 安全理念
+安装后重启终端或执行：
 
-1. **默认拒绝** — 外部 Skill 没有声明就没有权限
-2. **硬基线不可绕过** — 即使权限配置错误也无法覆盖
-3. **诚实文档** — 只声明已实现的能力，不画饼
-4. **纵深防御** — 多层防护防止单点失效
+```bash
+source ~/.zshrc  # 或 ~/.bashrc
+```
 
-## 技术差异（对比 OpenClaw）
+也可以从 [GitHub Releases](https://github.com/longzhi/clawhive/releases) 手动下载。
 
-| 维度 | clawhive | OpenClaw |
-|------|----------|----------|
-| **运行时** | 纯 Rust 二进制 + 嵌入式 SQLite | Node.js |
-| **安全模型** | 两层策略（硬基线 + 来源信任） | 工具白名单 |
-| **权限系统** | 声明式 SKILL.md 权限 | 运行时策略 |
-| **记忆** | Markdown 原生（MEMORY.md 为准） | Markdown 原生（MEMORY.md + memory/*.md） |
-| **集成渠道** | 多渠道（Telegram、Discord、Slack、WhatsApp、iMessage、CLI） | 广泛连接器 |
-| **依赖** | 单文件，零运行时依赖 | Node.js + npm |
+## 配置
 
-### 关键架构选择
+通过以下任一方式配置提供商、Agent 和渠道：
 
-- **Rust workspace + 嵌入式 SQLite**（`rusqlite` + bundled）：生产环境零运行时依赖
-- **Markdown 优先的记忆**：`MEMORY.md` 和每日文件为权威数据源；SQLite 索引可重建
-- **权限即代码**：Skill 在 YAML frontmatter 中声明权限，运行时强制执行
-- **有限执行**：Token 桶限流、子 Agent 递归限制、超时控制
+**方式 A：Web 配置向导** — 启动服务后在浏览器中打开向导：
+
+```bash
+clawhive start
+# 在浏览器中打开 http://localhost:3000/setup
+```
+
+**方式 B：CLI 配置向导** — 运行交互式终端向导：
+
+```bash
+clawhive setup
+```
+
+## 使用
+
+```bash
+# 配置
+clawhive setup
+clawhive validate
+
+# 聊天模式（本地 REPL）
+clawhive chat
+
+# 服务生命周期
+clawhive up                  # 后台守护进程启动（等效于 start -d）
+clawhive start               # 前台启动
+clawhive start --daemon      # 后台守护进程启动（别名：-d）
+clawhive restart
+clawhive stop
+
+# 仪表板模式（可观测性 TUI）
+clawhive dashboard
+
+# 编码模式（开发者 TUI）
+clawhive code
+
+# Agent / 会话
+clawhive agent list
+clawhive agent show clawhive-main
+clawhive session reset <session_key>
+
+# 定时任务
+clawhive schedule list
+clawhive schedule run <schedule_id>
+clawhive task trigger clawhive-main "总结今天的工作"
+
+# 日志
+clawhive logs
+
+# 认证
+clawhive auth status
+clawhive auth login openai
+```
+
+## CLI 命令
+
+| 命令 | 说明 |
+|------|------|
+| `setup` | 交互式配置向导 |
+| `up` | 后台守护进程启动（等效于 `start -d`） |
+| `start [--tui] [--daemon]` | 启动所有已配置的渠道 Bot 和 HTTP API 服务器 |
+| `stop` | 停止运行中的 clawhive 进程 |
+| `restart` | 重启 clawhive（stop + start） |
+| `chat [--agent <id>]` | 本地 REPL 测试 |
+| `validate` | 验证 YAML 配置 |
+| `consolidate` | 手动运行记忆整合 |
+| `logs` | 实时查看最新日志 |
+| `agent list\|show\|enable\|disable` | Agent 管理 |
+| `skill list\|show\|analyze\|install` | Skill 管理 |
+| `session reset <key>` | 重置会话 |
+| `schedule list\|run\|enable\|disable\|history` | 定时任务管理 |
+| `wait list` | 列出后台等待任务 |
+| `task trigger <agent> <task>` | 向 Agent 发送一次性任务 |
+| `auth login\|status` | OAuth 认证管理 |
+
+## 为什么选择 clawhive？
+
+- **极致轻量** — 单文件约 14MB，树莓派、VPS、Mac Mini 都能跑。没有 GC 停顿，内存可预测。
+- **安全先行** — 两层安全模型：不可绕过的硬基线 + 基于来源的信任。第三方 Skill 必须显式声明权限。
+- **有限执行** — 强制的 Token 预算、超时限制和子 Agent 递归深度限制。不会有无限循环，不会有天价账单。
+- **Web + CLI 配置** — 浏览器向导或交互式 CLI，2 分钟内跑起你的第一个 Agent。
 
 ## 功能特性
 
 - 多 Agent 编排：每个 Agent 有独立的人设、模型路由和记忆策略
-- 三层记忆系统：会话 JSONL（工作记忆）→ 每日文件（短期记忆）→ MEMORY.md（长期记忆）
-- 混合搜索：sqlite-vec 向量相似度（70%）+ FTS5 BM25（30%）
+- 三层记忆系统：会话 JSONL → 每日文件 → MEMORY.md（长期记忆）
+- 混合搜索：sqlite-vec 向量相似度 + FTS5 BM25
 - 海马体整合：LLM 定期将每日观察提炼为长期记忆
 - 渠道适配：Telegram、Discord、Slack、WhatsApp、iMessage（多 Bot、多连接器）
-- ReAct 推理循环 + 防空转保护
-- 子 Agent 生成（深度限制 + 超时）
-- Skill 系统（SKILL.md frontmatter + 提示注入）
+- ReAct 推理循环 + 防空转保护、子 Agent 生成
+- Skill 系统（SKILL.md frontmatter + 权限声明）
 - 按用户 Token 桶限流
 - LLM 提供商抽象 + 重试 + 指数退避（Anthropic、OpenAI、Gemini、DeepSeek、Groq、Ollama、OpenRouter、Together、Fireworks，以及任何 OpenAI 兼容端点）
-- 实时 TUI 仪表板（会话、事件、Agent 状态）
-- YAML 驱动配置（Agent、提供商、路由）
+- 实时 TUI 仪表板、YAML 驱动配置
 
 ## 架构
 
 ![clawhive 架构图](assets/architecture.png)
 
-## 项目结构
+<details>
+<summary><strong>项目结构</strong></summary>
 
 ```
 crates/
@@ -148,186 +162,112 @@ crates/
 └── logs/                # 日志文件
 ```
 
-## 安装
+</details>
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/longzhi/clawhive/main/install.sh | bash
+<details>
+<summary><strong>安全模型</strong></summary>
+
+clawhive 实现了**两层安全架构**，为 AI Agent 的工具执行提供纵深防御：
+
+**硬基线（始终强制）**
+
+| 防护类型 | 拦截内容 |
+|---------|---------|
+| **SSRF 防护** | 私有网络（10.x、172.16-31.x、192.168.x）、回环地址、云元数据端点 |
+| **敏感路径保护** | 写入 `~/.ssh/`、`~/.gnupg/`、`~/.aws/`、`/etc/` 等系统目录 |
+| **私钥防护** | 读取 `~/.ssh/id_*`、`~/.gnupg/private-keys`、云凭证 |
+| **危险命令拦截** | `rm -rf /`、fork bomb、磁盘擦除、curl 管道到 shell |
+| **资源限制** | 30 秒超时、1MB 输出上限、5 个并发执行 |
+
+**基于来源的信任模型**
+
+| 来源 | 信任级别 | 权限检查 |
+|------|---------|---------|
+| **内置** | 受信任 | 仅硬基线 |
+| **外部** | 沙箱化 | 必须在 SKILL.md frontmatter 中声明所有权限 |
+
+外部 Skill 在 SKILL.md 中声明权限：
+
+```yaml
+---
+name: weather-skill
+permissions:
+  network:
+    allow: ["api.openweathermap.org:443"]
+  fs:
+    read: ["${WORKSPACE}/**"]
+  exec: [curl, jq]
+  env: [WEATHER_API_KEY]
+---
 ```
 
-自动检测操作系统和架构，下载最新版本，将二进制文件和 Skill 安装到 `~/.clawhive/`。
+未声明的权限在运行时一律拒绝。
 
-安装后重启终端或执行：
+</details>
 
-```bash
-source ~/.zshrc  # 或 ~/.bashrc
-```
+<details>
+<summary><strong>记忆系统</strong></summary>
 
-也可以从 [GitHub Releases](https://github.com/longzhi/clawhive/releases) 手动下载。
+受神经科学启发的三层记忆架构：
 
-### 配置
+1. **会话 JSONL**（`sessions/<id>.jsonl`）— 追加式对话日志，类型化条目。用于会话恢复和审计追踪。
+2. **每日文件**（`memory/YYYY-MM-DD.md`）— LLM 在对话中写入的每日观察。
+3. **MEMORY.md** — 策展的长期知识。通过海马体整合（LLM 对近期每日文件的综合提炼）来更新。
+4. **SQLite 搜索索引** — sqlite-vec + FTS5。混合搜索：向量相似度 × 0.7 + BM25 × 0.3。
 
-安装后，通过以下任一方式配置提供商、Agent 和渠道：
+注意：JSONL 文件不参与索引。只有 Markdown 记忆文件参与搜索。
 
-**方式 A：Web 配置向导** — 启动服务后在浏览器中打开向导：
+</details>
 
-```bash
-clawhive start
-# 在浏览器中打开 http://localhost:3000/setup
-```
+<details>
+<summary><strong>技术对比（vs OpenClaw）</strong></summary>
 
-**方式 B：CLI 配置向导** — 运行交互式终端向导：
+| 维度 | clawhive | OpenClaw |
+|------|----------|----------|
+| **运行时** | 纯 Rust 二进制 + 嵌入式 SQLite | Node.js |
+| **安全模型** | 两层策略（硬基线 + 来源信任） | 工具白名单 |
+| **权限系统** | 声明式 SKILL.md 权限 | 运行时策略 |
+| **记忆** | Markdown 原生（MEMORY.md 为准） | Markdown 原生（MEMORY.md + memory/*.md） |
+| **集成渠道** | 多渠道（Telegram、Discord、Slack、WhatsApp、iMessage、CLI） | 广泛连接器 |
+| **依赖** | 单文件，零运行时依赖 | Node.js + npm |
 
-```bash
-clawhive setup
-```
+</details>
 
-### 运行
-
-```bash
-# 配置
-clawhive setup
-clawhive validate
-
-# 聊天模式（本地 REPL）
-clawhive chat
-
-# 服务生命周期
-clawhive start
-clawhive start --daemon  # 别名：-d
-clawhive restart
-clawhive restart --daemon  # 别名：-d
-clawhive stop
-
-# 仪表板模式（可观测性 TUI）
-clawhive dashboard
-clawhive dashboard --port 3000
-
-# 编码模式（开发者 TUI）
-clawhive code
-clawhive code --port 3000
-
-# Agent / 会话
-clawhive agent list
-clawhive agent show clawhive-main
-clawhive session reset <session_key>
-
-# 定时任务
-clawhive schedule list
-clawhive schedule run <schedule_id>
-clawhive task trigger clawhive-main "总结今天的工作"
-
-# 认证
-clawhive auth status
-clawhive auth login openai
-```
-
-## 快速开始（开发者）
-
-前置条件：Rust 1.92+
-
-```bash
-# 克隆并构建
-git clone https://github.com/longzhi/clawhive.git
-cd clawhive
-cargo build --workspace
-
-# 交互式配置（配置提供商、Agent、渠道）
-cargo run -- setup
-
-# 聊天模式（本地 REPL）
-cargo run -- chat
-
-# 启动所有已配置的渠道 Bot
-cargo run -- start
-
-# 以守护进程方式启动
-cargo run -- start --daemon  # 别名：-d
-
-# 重启 / 停止
-cargo run -- restart
-cargo run -- restart --daemon
-cargo run -- stop
-
-# 仪表板模式（可观测性 TUI）
-cargo run -- dashboard
-cargo run -- dashboard --port 3000
-
-# 编码 Agent 模式（将本地 TUI 渠道接入运行中的网关）
-cargo run -- code
-cargo run -- code --port 3000
-```
-
-## 开发者工作流
-
-推送前使用本地质量检查：
-
-```bash
-# 一次性：安装仓库管理的 git hooks
-just install-hooks
-
-# 运行所有 CI 等效检查
-just check
-
-# 发布流程：check -> push main -> 替换 tag 并推送
-just release v0.1.0-alpha.15
-```
-
-如果不用 `just`，可以直接执行脚本：
-
-```bash
-bash scripts/install-git-hooks.sh
-bash scripts/check.sh
-bash scripts/release.sh v0.1.0-alpha.15
-```
-
-`just check` 会执行：
-
-1. `cargo fmt --all -- --check`
-2. `cargo clippy --workspace --all-targets -- -D warnings`
-3. `cargo test --workspace`
-
-## 配置说明
+<details>
+<summary><strong>配置说明</strong></summary>
 
 配置通过 `clawhive setup` 管理，交互式生成 YAML 文件到 `~/.clawhive/config/`：
 
 - `main.yaml` — 应用名称、运行时设置、功能开关、渠道配置
-- `agents.d/<agent_id>.yaml` — Agent 身份（名称、emoji）、模型策略（主模型 + 备用）、工具策略、记忆策略
-- `providers.d/<provider>.yaml` — 提供商类型、API 地址、认证方式（API Key 或 OAuth）
+- `agents.d/<agent_id>.yaml` — Agent 身份、模型策略、工具策略、记忆策略
+- `providers.d/<provider>.yaml` — 提供商类型、API 地址、认证方式
 - `routing.yaml` — 默认 Agent ID、渠道到 Agent 的路由绑定
 
 支持的提供商：Anthropic、OpenAI、Gemini、DeepSeek、Groq、Ollama、OpenRouter、Together、Fireworks，以及任何 OpenAI 兼容端点。
 
-## 记忆系统
-
-clawhive 使用受神经科学启发的三层记忆架构：
-
-1. **会话 JSONL**（`sessions/<id>.jsonl`）— 追加式对话日志，类型化条目（message、tool_call、tool_result、compaction、model_change）。用于会话恢复和审计追踪。
-2. **每日文件**（`memory/YYYY-MM-DD.md`）— LLM 在对话中写入的每日观察。如果会话中 LLM 没有写入，会生成备用摘要。
-3. **MEMORY.md** — 策展的长期知识。通过海马体整合（LLM 对近期每日文件的综合提炼）和 LLM 直接写入来更新。
-4. **SQLite 搜索索引** — sqlite-vec 0.1.6 + FTS5。Markdown 文件分块（约 400 token，80 token 重叠），嵌入、索引。混合搜索：向量相似度 × 0.7 + BM25 × 0.3。
-
-注意：JSONL 文件不参与索引（噪音太大）。只有 Markdown 记忆文件参与搜索。
-
-## CLI 命令
-
-| 命令 | 说明 |
-|------|------|
-| `setup` | 交互式配置向导 |
-| `start [--tui] [--daemon]` | 启动所有已配置的渠道 Bot 和 HTTP API 服务器 |
-| `stop` | 停止运行中的 clawhive 进程 |
-| `restart` | 重启 clawhive（stop + start） |
-| `chat [--agent <id>]` | 本地 REPL 测试 |
-| `validate` | 验证 YAML 配置 |
-| `consolidate` | 手动运行记忆整合 |
-| `agent list\|show\|enable\|disable` | Agent 管理 |
-| `skill list\|show\|analyze\|install` | Skill 管理 |
-| `session reset <key>` | 重置会话 |
-| `schedule list\|run\|enable\|disable\|history` | 定时任务管理 |
-| `wait list` | 列出后台等待任务 |
-| `task trigger <agent> <task>` | 向 Agent 发送一次性任务 |
-| `auth login\|status` | OAuth 认证管理 |
+</details>
 
 ## 开发
+
+<details>
+<summary><strong>快速开始（开发者）</strong></summary>
+
+前置条件：Rust 1.92+
+
+```bash
+git clone https://github.com/longzhi/clawhive.git
+cd clawhive
+cargo build --workspace
+
+cargo run -- setup       # 交互式配置
+cargo run -- chat        # 聊天模式
+cargo run -- start       # 启动所有渠道 Bot
+cargo run -- start -d    # 后台守护进程启动
+cargo run -- dashboard   # 仪表板模式
+cargo run -- code        # 编码 Agent 模式
+```
+
+</details>
 
 ```bash
 # 运行所有测试
@@ -338,6 +278,12 @@ cargo clippy --workspace --all-targets -- -D warnings
 
 # 格式化
 cargo fmt --all
+
+# 运行所有 CI 等效检查
+just check
+
+# 发布
+just release v0.1.0-alpha.15
 ```
 
 ## 技术栈


### PR DESCRIPTION
## Summary
- Move Installation, Setup, Usage sections to the top of README for better user experience
- Add `clawhive up` and `clawhive logs` to CLI commands documentation
- Collapse technical details (security model, memory system, project structure, comparison) into `<details>` sections
- Sync Chinese README (README_CN.md) with the same structure

## Test plan
- [ ] Verify README renders correctly on GitHub (especially `<details>` sections)
- [ ] Verify README_CN.md renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)