### PR TITLE
feat(cli): add config command, unify main.yaml, improve setup UX

### DIFF
--- a/crates/clawhive-cli/src/commands/config.rs
+++ b/crates/clawhive-cli/src/commands/config.rs
@@ -1,0 +1,211 @@
+use std::path::Path;
+
+use anyhow::Result;
+use clawhive_core::config::{ClawhiveConfig, SecurityMode};
+use clawhive_core::load_config;
+use console::style;
+
+/// Mask a secret string, showing first 4 and last 4 characters.
+fn mask_token(s: &str) -> String {
+    if s.len() <= 10 {
+        return "****".to_string();
+    }
+    let prefix = &s[..4];
+    let suffix = &s[s.len() - 4..];
+    format!("{prefix}****{suffix}")
+}
+
+pub fn print_config(root: &Path) -> Result<()> {
+    let config_path = root.join("config");
+    let config = load_config(&config_path)?;
+    print_config_detail(&config);
+    Ok(())
+}
+
+fn print_config_detail(config: &ClawhiveConfig) {
+    let main = &config.main;
+
+    println!();
+    println!("{}", style("═══ clawhive config ═══").bold().cyan());
+
+    // ── App ──
+    println!();
+    println!("{}", style("app:").bold());
+    println!("  name: {}", main.app.name);
+
+    // ── Runtime ──
+    println!();
+    println!("{}", style("runtime:").bold());
+    println!("  max_concurrent: {}", main.runtime.max_concurrent);
+
+    // ── Features ──
+    println!();
+    println!("{}", style("features:").bold());
+    println!("  multi_agent: {}", main.features.multi_agent);
+    println!("  sub_agent: {}", main.features.sub_agent);
+    println!("  tui: {}", main.features.tui);
+    println!("  cli: {}", main.features.cli);
+
+    // ── Channels ──
+    println!();
+    println!("{}", style("channels:").bold());
+    if let Some(tg) = &main.channels.telegram {
+        println!("  telegram:");
+        println!("    enabled: {}", tg.enabled);
+        println!("    connectors:");
+        for c in &tg.connectors {
+            println!("      - connector_id: {}", c.connector_id);
+            println!("        token: {}", style(mask_token(&c.token)).yellow());
+            println!("        require_mention: {}", c.require_mention);
+        }
+    }
+    if let Some(dc) = &main.channels.discord {
+        println!("  discord:");
+        println!("    enabled: {}", dc.enabled);
+        println!("    connectors:");
+        for c in &dc.connectors {
+            println!("      - connector_id: {}", c.connector_id);
+            println!("        token: {}", style(mask_token(&c.token)).yellow());
+            println!("        require_mention: {}", c.require_mention);
+            if !c.groups.is_empty() {
+                println!("        groups: {:?}", c.groups);
+            }
+        }
+    }
+    if main.channels.telegram.is_none() && main.channels.discord.is_none() {
+        println!("  {}", style("(none configured)").yellow());
+    }
+
+    // ── Embedding ──
+    println!();
+    println!("{}", style("embedding:").bold());
+    println!("  enabled: {}", main.embedding.enabled);
+    println!("  provider: {}", main.embedding.provider);
+    println!("  model: {}", main.embedding.model);
+    if !main.embedding.api_key.is_empty() {
+        println!(
+            "  api_key: {}",
+            style(mask_token(&main.embedding.api_key)).yellow()
+        );
+    }
+
+    // ── Tools ──
+    println!();
+    println!("{}", style("tools:").bold());
+    match &main.tools.web_search {
+        Some(ws) => {
+            println!("  web_search:");
+            println!("    enabled: {}", ws.enabled);
+            if let Some(p) = &ws.provider {
+                println!("    provider: {p}");
+            }
+            if let Some(k) = &ws.api_key {
+                println!("    api_key: {}", style(mask_token(k)).yellow());
+            }
+        }
+        None => {
+            println!("  web_search: {}", style("off").yellow());
+        }
+    }
+    match &main.tools.actionbook {
+        Some(ab) => println!("  actionbook: {}", if ab.enabled { "on" } else { "off" }),
+        None => println!("  actionbook: {}", style("off").yellow()),
+    }
+
+    // ── Providers ──
+    println!();
+    println!("{}", style("providers:").bold());
+    if config.providers.is_empty() {
+        println!("  {}", style("(none configured)").yellow());
+    }
+    for p in &config.providers {
+        println!("  - provider_id: {}", style(&p.provider_id).cyan());
+        println!("    enabled: {}", p.enabled);
+        println!("    api_base: {}", p.api_base);
+        if let Some(key) = &p.api_key {
+            if !key.is_empty() {
+                println!("    api_key: {}", style(mask_token(key)).yellow());
+            }
+        }
+        if let Some(profile) = &p.auth_profile {
+            println!("    auth_profile: {profile}");
+        }
+        if !p.models.is_empty() {
+            println!("    models: {:?}", p.models);
+        }
+    }
+
+    // ── Agents ──
+    println!();
+    println!("{}", style("agents:").bold());
+    if config.agents.is_empty() {
+        println!("  {}", style("(none configured)").yellow());
+    }
+    for a in &config.agents {
+        println!("  - agent_id: {}", style(&a.agent_id).cyan());
+        println!("    enabled: {}", a.enabled);
+        if let Some(identity) = &a.identity {
+            println!(
+                "    identity: {} {}",
+                identity.emoji.as_deref().unwrap_or(""),
+                identity.name
+            );
+        }
+        println!("    model: {}", a.model_policy.primary);
+        if !a.model_policy.fallbacks.is_empty() {
+            println!("    fallbacks: {:?}", a.model_policy.fallbacks);
+        }
+        let security_label = match a.security {
+            SecurityMode::Standard => "standard",
+            SecurityMode::Off => "off",
+        };
+        println!("    security: {security_label}");
+        if let Some(hb) = &a.heartbeat {
+            println!(
+                "    heartbeat: {} ({}m)",
+                if hb.enabled { "on" } else { "off" },
+                hb.interval_minutes
+            );
+        }
+    }
+
+    // ── Routing ──
+    println!();
+    println!("{}", style("routing:").bold());
+    println!(
+        "  default_agent_id: {}",
+        style(&config.routing.default_agent_id).cyan()
+    );
+    if !config.routing.bindings.is_empty() {
+        println!("  bindings:");
+        for b in &config.routing.bindings {
+            println!(
+                "    - {} / {} ({}: {}) → {}",
+                b.channel_type,
+                b.connector_id,
+                b.match_rule.kind,
+                b.match_rule.pattern.as_deref().unwrap_or("*"),
+                style(&b.agent_id).cyan()
+            );
+        }
+    }
+
+    println!();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mask_token_short() {
+        assert_eq!(mask_token("abc"), "****");
+        assert_eq!(mask_token("1234567890"), "****");
+    }
+
+    #[test]
+    fn mask_token_long() {
+        assert_eq!(mask_token("12345678901"), "1234****8901");
+        assert_eq!(mask_token("sk-ant-api03-abcdefghijklmnop"), "sk-a****mnop");
+    }
+}

--- a/crates/clawhive-cli/src/commands/mod.rs
+++ b/crates/clawhive-cli/src/commands/mod.rs
@@ -1,3 +1,4 @@
 pub mod auth;
+pub mod config;
 pub mod status;
 pub mod update;

--- a/crates/clawhive-cli/src/commands/status.rs
+++ b/crates/clawhive-cli/src/commands/status.rs
@@ -50,7 +50,7 @@ fn render_table(title: &str, rows: &[(&str, String)]) {
             println!("{sep}");
         }
         let val_visible = visible_len(value);
-        let val_pad = (vw - 1).saturating_sub(val_visible);
+        let val_pad = vw.saturating_sub(val_visible + 2);
         println!(
             "│ {:<width$}│ {}{} │",
             label,

--- a/crates/clawhive-cli/src/main.rs
+++ b/crates/clawhive-cli/src/main.rs
@@ -43,6 +43,9 @@ use commands::auth::{handle_auth_command, AuthCommands};
 use setup::run_setup;
 use tokio::time::sleep;
 
+/// Default HTTP API server port.
+const DEFAULT_PORT: u16 = 8848;
+
 #[derive(Parser)]
 #[command(name = "clawhive", version, about = "clawhive AI agent framework")]
 struct Cli {
@@ -65,7 +68,7 @@ enum Commands {
         daemon: bool,
         #[arg(long, help = "Run TUI dashboard in the same process")]
         tui: bool,
-        #[arg(long, default_value = "8848", help = "HTTP API server port")]
+        #[arg(long, default_value_t = DEFAULT_PORT, help = "HTTP API server port")]
         port: u16,
         /// Override security mode (overrides agent config)
         #[arg(long, value_name = "MODE")]
@@ -76,7 +79,7 @@ enum Commands {
     },
     #[command(about = "Start clawhive as a background daemon (alias for `start -d`)")]
     Up {
-        #[arg(long, default_value = "8848", help = "HTTP API server port")]
+        #[arg(long, default_value_t = DEFAULT_PORT, help = "HTTP API server port")]
         port: u16,
         /// Override security mode (overrides agent config)
         #[arg(long, value_name = "MODE")]
@@ -91,7 +94,7 @@ enum Commands {
     Stop,
     #[command(about = "Restart clawhive (stop + start as daemon)")]
     Restart {
-        #[arg(long, default_value = "8848", help = "HTTP API server port")]
+        #[arg(long, default_value_t = DEFAULT_PORT, help = "HTTP API server port")]
         port: u16,
         /// Override security mode (overrides agent config)
         #[arg(long, value_name = "MODE")]
@@ -102,7 +105,7 @@ enum Commands {
     },
     #[command(about = "Code mode: open developer TUI")]
     Code {
-        #[arg(long, default_value = "8848", help = "HTTP API server port")]
+        #[arg(long, default_value_t = DEFAULT_PORT, help = "HTTP API server port")]
         port: u16,
         /// Override security mode (overrides agent config)
         #[arg(long, value_name = "MODE")]
@@ -113,7 +116,7 @@ enum Commands {
     },
     #[command(about = "Dashboard mode: attach TUI observability panel to running gateway")]
     Dashboard {
-        #[arg(long, default_value = "8848", help = "HTTP API server port")]
+        #[arg(long, default_value_t = DEFAULT_PORT, help = "HTTP API server port")]
         port: u16,
     },
     #[command(about = "Local REPL for testing (no Telegram needed)")]
@@ -127,6 +130,8 @@ enum Commands {
         #[arg(long)]
         no_security: bool,
     },
+    #[command(about = "Show current configuration (tokens masked)")]
+    Config,
     #[command(about = "Validate config files")]
     Validate,
     #[command(about = "Run memory consolidation manually")]
@@ -409,6 +414,9 @@ async fn main() -> Result<()> {
     };
 
     match command {
+        Commands::Config => {
+            commands::config::print_config(&cli.config_root)?;
+        }
         Commands::Validate => {
             let config = load_config(&cli.config_root.join("config"))?;
             println!(

--- a/crates/clawhive-cli/src/setup.rs
+++ b/crates/clawhive-cli/src/setup.rs
@@ -11,6 +11,11 @@ use clawhive_auth::{AuthProfile, TokenManager};
 use console::{style, Term};
 use dialoguer::{theme::ColorfulTheme, Confirm, Input, Select};
 
+use clawhive_core::config::{
+    ActionbookConfig, DiscordChannelConfig, DiscordConnectorConfig, MainConfig,
+    TelegramChannelConfig, TelegramConnectorConfig, WebSearchConfig,
+};
+
 use crate::setup_scan::{scan_config, ConfigState};
 use crate::setup_ui::{print_done, print_logo, render_dashboard, ARROW, CRAB};
 
@@ -246,12 +251,9 @@ fn handle_set_web_password(config_root: &Path, theme: &ColorfulTheme, term: &Ter
             .map_err(|e| anyhow!("Failed to hash password: {e}"))?;
 
         // Write hash to main.yaml
-        let content = fs::read_to_string(&main_yaml_path).unwrap_or_default();
-        let mut doc: serde_yaml::Value = serde_yaml::from_str(&content)
-            .unwrap_or_else(|_| serde_yaml::Value::Mapping(serde_yaml::Mapping::new()));
-        doc["web_password_hash"] = serde_yaml::Value::String(hash);
-        let yaml = serde_yaml::to_string(&doc)?;
-        fs::write(&main_yaml_path, yaml)?;
+        let mut cfg = load_main_config(config_root)?;
+        cfg.web_password_hash = Some(hash);
+        save_main_config(config_root, &cfg)?;
 
         term.write_line(&format!(
             "    {} {}",
@@ -331,16 +333,35 @@ async fn handle_add_provider(
             .any(|item| item.provider_id == provider.as_str())
     };
     if fully_configured && !force {
-        let should_reconfigure = Confirm::with_theme(theme)
-            .with_prompt(format!(
-                "{} already configured. Reconfigure?",
-                provider.as_str()
-            ))
-            .default(false)
+        let actions = ["Reconfigure", "Remove", "Cancel"];
+        let selected = Select::with_theme(theme)
+            .with_prompt(format!("{} already configured", provider.as_str()))
+            .items(&actions)
+            .default(2)
             .interact()?;
-        if !should_reconfigure {
-            term.write_line("Provider unchanged.")?;
-            return Ok(());
+        match selected {
+            0 => { /* continue to reconfigure below */ }
+            1 => {
+                if Confirm::with_theme(theme)
+                    .with_prompt(format!(
+                        "Are you sure you want to remove {}?",
+                        provider.as_str()
+                    ))
+                    .default(false)
+                    .interact()?
+                {
+                    let path =
+                        config_root.join(format!("config/providers.d/{}.yaml", provider.as_str()));
+                    if path.exists() {
+                        fs::remove_file(&path)?;
+                    }
+                    print_done(term, &format!("Provider {} removed.", provider.as_str()));
+                }
+                return Ok(());
+            }
+            _ => {
+                return Ok(());
+            }
         }
     }
 
@@ -402,12 +423,31 @@ fn handle_add_agent(
 
     let existing = state.agents.iter().any(|a| a.agent_id == agent_id);
     if existing && !force {
-        let reconfigure = Confirm::with_theme(theme)
-            .with_prompt(format!("{agent_id} already configured. Reconfigure?"))
-            .default(false)
+        let actions = ["Reconfigure", "Remove", "Cancel"];
+        let selected = Select::with_theme(theme)
+            .with_prompt(format!("{agent_id} already configured"))
+            .items(&actions)
+            .default(2)
             .interact()?;
-        if !reconfigure {
-            return Ok(());
+        match selected {
+            0 => { /* continue to reconfigure below */ }
+            1 => {
+                if Confirm::with_theme(theme)
+                    .with_prompt(format!("Are you sure you want to remove {agent_id}?"))
+                    .default(false)
+                    .interact()?
+                {
+                    let path = config_root.join(format!("config/agents.d/{agent_id}.yaml"));
+                    if path.exists() {
+                        fs::remove_file(&path)?;
+                    }
+                    print_done(&Term::stdout(), &format!("Agent {agent_id} removed."));
+                }
+                return Ok(());
+            }
+            _ => {
+                return Ok(());
+            }
         }
     }
 
@@ -568,7 +608,6 @@ fn handle_add_channel(
 
 fn handle_configure_tools(config_root: &Path, theme: &ColorfulTheme) -> Result<()> {
     let term = Term::stdout();
-    let main_path = config_root.join("config/main.yaml");
 
     let enable_ws = Confirm::with_theme(theme)
         .with_prompt("Enable web search?")
@@ -596,28 +635,13 @@ fn handle_configure_tools(config_root: &Path, theme: &ColorfulTheme) -> Result<(
         (None, None)
     };
 
-    if !main_path.exists() {
-        let yaml = generate_main_yaml("clawhive", None, None);
-        fs::write(&main_path, yaml)?;
-    }
-
-    let content = fs::read_to_string(&main_path)?;
-    let mut doc: serde_yaml::Value = serde_yaml::from_str(&content)?;
-
-    let mut ws_map = serde_yaml::Mapping::new();
-    ws_map.insert("enabled".into(), serde_yaml::Value::Bool(enable_ws));
-    if let Some(p) = &provider {
-        ws_map.insert("provider".into(), serde_yaml::Value::String(p.clone()));
-    }
-    if let Some(k) = &api_key {
-        ws_map.insert("api_key".into(), serde_yaml::Value::String(k.clone()));
-    }
-
-    let mut tools_map = serde_yaml::Mapping::new();
-    tools_map.insert("web_search".into(), serde_yaml::Value::Mapping(ws_map));
-    doc["tools"] = serde_yaml::Value::Mapping(tools_map);
-
-    fs::write(&main_path, serde_yaml::to_string(&doc)?)?;
+    let mut cfg = load_main_config(config_root)?;
+    cfg.tools.web_search = Some(WebSearchConfig {
+        enabled: enable_ws,
+        provider: provider.clone(),
+        api_key: api_key.clone(),
+    });
+    save_main_config(config_root, &cfg)?;
 
     let ab_installed = clawhive_core::bin_exists("actionbook");
     let ab_prompt = if ab_installed {
@@ -668,16 +692,9 @@ fn handle_configure_tools(config_root: &Path, theme: &ColorfulTheme) -> Result<(
         }
     }
 
-    let content = fs::read_to_string(&main_path)?;
-    let mut doc: serde_yaml::Value = serde_yaml::from_str(&content)?;
-    if !doc["tools"].is_mapping() {
-        doc["tools"] = serde_yaml::Value::Mapping(serde_yaml::Mapping::new());
-    }
-    let mut ab_map = serde_yaml::Mapping::new();
-    ab_map.insert("enabled".into(), serde_yaml::Value::Bool(enable_ab));
-    doc["tools"]["actionbook"] = serde_yaml::Value::Mapping(ab_map);
-
-    fs::write(&main_path, serde_yaml::to_string(&doc)?)?;
+    let mut cfg = load_main_config(config_root)?;
+    cfg.tools.actionbook = Some(ActionbookConfig { enabled: enable_ab });
+    save_main_config(config_root, &cfg)?;
     print_done(
         &Term::stdout(),
         &format!(
@@ -825,125 +842,54 @@ fn add_channel_to_config(
     channel_type: &str,
     cfg: &ChannelConfig,
 ) -> Result<()> {
-    let main_path = config_root.join("config/main.yaml");
-    if !main_path.exists() {
-        let tg = if channel_type == "telegram" {
-            Some(cfg.clone())
-        } else {
-            None
-        };
-        let dc = if channel_type == "discord" {
-            Some(cfg.clone())
-        } else {
-            None
-        };
-        let yaml = generate_main_yaml("clawhive", tg, dc);
-        fs::write(&main_path, yaml)?;
-        return Ok(());
-    }
+    let mut main_cfg = load_main_config(config_root)?;
 
-    let content = fs::read_to_string(&main_path)?;
-    let mut doc: serde_yaml::Value = serde_yaml::from_str(&content)?;
-
-    // Ensure required top-level sections exist with defaults
-    if doc.get("app").is_none() {
-        doc["app"] = serde_yaml::to_value(serde_yaml::Mapping::from_iter([(
-            serde_yaml::Value::String("name".into()),
-            serde_yaml::Value::String("clawhive".into()),
-        )]))?;
-    }
-    if doc.get("runtime").is_none() {
-        doc["runtime"] = serde_yaml::to_value(serde_yaml::Mapping::from_iter([(
-            serde_yaml::Value::String("max_concurrent".into()),
-            serde_yaml::Value::Number(4.into()),
-        )]))?;
-    }
-    if doc.get("features").is_none() {
-        doc["features"] = serde_yaml::to_value(serde_yaml::Mapping::from_iter([
-            (
-                serde_yaml::Value::String("multi_agent".into()),
-                serde_yaml::Value::Bool(true),
-            ),
-            (
-                serde_yaml::Value::String("sub_agent".into()),
-                serde_yaml::Value::Bool(true),
-            ),
-            (
-                serde_yaml::Value::String("tui".into()),
-                serde_yaml::Value::Bool(true),
-            ),
-            (
-                serde_yaml::Value::String("cli".into()),
-                serde_yaml::Value::Bool(true),
-            ),
-        ]))?;
-    }
-    if doc.get("channels").is_none() {
-        doc["channels"] = serde_yaml::Value::Mapping(serde_yaml::Mapping::new());
-    }
-
-    let channels = doc
-        .get_mut("channels")
-        .and_then(|c| c.as_mapping_mut())
-        .ok_or_else(|| anyhow!("main.yaml missing channels section"))?;
-
-    let mut connector_map = serde_yaml::Mapping::new();
-    connector_map.insert(
-        serde_yaml::Value::String("connector_id".into()),
-        serde_yaml::Value::String(cfg.connector_id.clone()),
-    );
-    connector_map.insert(
-        serde_yaml::Value::String("token".into()),
-        serde_yaml::Value::String(cfg.token.clone()),
-    );
-    if channel_type == "discord" && !cfg.groups.is_empty() {
-        let groups_seq: Vec<serde_yaml::Value> = cfg
-            .groups
-            .iter()
-            .map(|g| serde_yaml::Value::String(g.clone()))
-            .collect();
-        connector_map.insert(
-            serde_yaml::Value::String("groups".into()),
-            serde_yaml::Value::Sequence(groups_seq),
-        );
-    }
-    if !cfg.require_mention {
-        connector_map.insert(
-            serde_yaml::Value::String("require_mention".into()),
-            serde_yaml::Value::Bool(false),
-        );
-    }
-    let connector_value = serde_yaml::Value::Mapping(connector_map);
-
-    let channel_key = serde_yaml::Value::String(channel_type.to_string());
-    match channels.get_mut(&channel_key) {
-        Some(section) => {
-            section["enabled"] = serde_yaml::Value::Bool(true);
-            if let Some(seq) = section
-                .get_mut("connectors")
-                .and_then(|connectors| connectors.as_sequence_mut())
-            {
-                seq.retain(|connector| {
-                    connector.get("connector_id").and_then(|v| v.as_str())
-                        != Some(&cfg.connector_id)
-                });
-                seq.push(connector_value);
-            } else {
-                section["connectors"] = serde_yaml::Value::Sequence(vec![connector_value]);
+    match channel_type {
+        "telegram" => {
+            let connector = TelegramConnectorConfig {
+                connector_id: cfg.connector_id.clone(),
+                token: cfg.token.clone(),
+                require_mention: cfg.require_mention,
+            };
+            match main_cfg.channels.telegram.as_mut() {
+                Some(tg) => {
+                    tg.enabled = true;
+                    tg.connectors.retain(|c| c.connector_id != cfg.connector_id);
+                    tg.connectors.push(connector);
+                }
+                None => {
+                    main_cfg.channels.telegram = Some(TelegramChannelConfig {
+                        enabled: true,
+                        connectors: vec![connector],
+                    });
+                }
             }
         }
-        None => {
-            let mut section = serde_yaml::Mapping::new();
-            section.insert("enabled".into(), serde_yaml::Value::Bool(true));
-            section.insert(
-                "connectors".into(),
-                serde_yaml::Value::Sequence(vec![connector_value]),
-            );
-            channels.insert(channel_key, serde_yaml::Value::Mapping(section));
+        "discord" => {
+            let connector = DiscordConnectorConfig {
+                connector_id: cfg.connector_id.clone(),
+                token: cfg.token.clone(),
+                groups: cfg.groups.clone(),
+                require_mention: cfg.require_mention,
+            };
+            match main_cfg.channels.discord.as_mut() {
+                Some(dc) => {
+                    dc.enabled = true;
+                    dc.connectors.retain(|c| c.connector_id != cfg.connector_id);
+                    dc.connectors.push(connector);
+                }
+                None => {
+                    main_cfg.channels.discord = Some(DiscordChannelConfig {
+                        enabled: true,
+                        connectors: vec![connector],
+                    });
+                }
+            }
         }
+        _ => return Err(anyhow!("unsupported channel type: {channel_type}")),
     }
 
-    fs::write(&main_path, serde_yaml::to_string(&doc)?)?;
+    save_main_config(config_root, &main_cfg)?;
     Ok(())
 }
 
@@ -1011,28 +957,14 @@ fn remove_channel_from_config(config_root: &Path, connector_id: &str) -> Result<
         return Ok(());
     }
 
-    let content = fs::read_to_string(&main_path)?;
-    let mut doc: serde_yaml::Value = serde_yaml::from_str(&content)?;
-    if let Some(channels) = doc
-        .get_mut("channels")
-        .and_then(|channels| channels.as_mapping_mut())
-    {
-        for (_channel, section) in channels.iter_mut() {
-            if let Some(connectors) = section
-                .get_mut("connectors")
-                .and_then(|connectors| connectors.as_sequence_mut())
-            {
-                connectors.retain(|connector| {
-                    connector
-                        .get("connector_id")
-                        .and_then(|value| value.as_str())
-                        != Some(connector_id)
-                });
-            }
-        }
+    let mut cfg = load_main_config(config_root)?;
+    if let Some(tg) = cfg.channels.telegram.as_mut() {
+        tg.connectors.retain(|c| c.connector_id != connector_id);
     }
-
-    fs::write(&main_path, serde_yaml::to_string(&doc)?)?;
+    if let Some(dc) = cfg.channels.discord.as_mut() {
+        dc.connectors.retain(|c| c.connector_id != connector_id);
+    }
+    save_main_config(config_root, &cfg)?;
     Ok(())
 }
 
@@ -1340,59 +1272,68 @@ fn generate_agent_yaml(agent_id: &str, name: &str, emoji: &str, primary_model: &
     )
 }
 
+/// Load `main.yaml` as a typed `MainConfig`, falling back to defaults if the
+/// file is missing or incomplete.
+fn load_main_config(config_root: &Path) -> Result<MainConfig> {
+    let main_path = config_root.join("config/main.yaml");
+    if !main_path.exists() {
+        return Ok(MainConfig::default());
+    }
+    let content = fs::read_to_string(&main_path)?;
+    // If the file exists but can't parse (e.g. only has web_password_hash),
+    // merge the raw value into a default config.
+    match serde_yaml::from_str::<MainConfig>(&content) {
+        Ok(cfg) => Ok(cfg),
+        Err(_) => {
+            // Parse as raw value and try to preserve web_password_hash
+            let raw: serde_yaml::Value = serde_yaml::from_str(&content)
+                .unwrap_or(serde_yaml::Value::Mapping(serde_yaml::Mapping::new()));
+            let mut cfg = MainConfig::default();
+            if let Some(hash) = raw.get("web_password_hash").and_then(|v| v.as_str()) {
+                cfg.web_password_hash = Some(hash.to_string());
+            }
+            Ok(cfg)
+        }
+    }
+}
+
+/// Save `MainConfig` to `config/main.yaml`.
+fn save_main_config(config_root: &Path, config: &MainConfig) -> Result<()> {
+    let main_path = config_root.join("config/main.yaml");
+    let yaml = serde_yaml::to_string(config)?;
+    fs::write(&main_path, yaml)?;
+    Ok(())
+}
+
+#[cfg(test)]
 fn generate_main_yaml(
-    app_name: &str,
+    _app_name: &str,
     telegram: Option<ChannelConfig>,
     discord: Option<ChannelConfig>,
 ) -> String {
-    let mut out = String::new();
-    out.push_str(&format!(
-        "app:\n  name: {app_name}\n\nruntime:\n  max_concurrent: 4\n\nfeatures:\n  multi_agent: true\n  sub_agent: true\n  tui: true\n  cli: true\n\nchannels:\n"
-    ));
-
-    match telegram {
-        Some(cfg) => {
-            out.push_str("  telegram:\n    enabled: true\n    connectors:\n");
-            out.push_str(&format!(
-                "      - connector_id: {}\n        token: \"{}\"\n",
-                cfg.connector_id, cfg.token
-            ));
-            if !cfg.require_mention {
-                out.push_str("        require_mention: false\n");
-            }
-        }
-        None => {
-            out.push_str("  telegram:\n    enabled: false\n    connectors: []\n");
-        }
+    let mut cfg = MainConfig::default();
+    if let Some(tg) = telegram {
+        cfg.channels.telegram = Some(TelegramChannelConfig {
+            enabled: true,
+            connectors: vec![TelegramConnectorConfig {
+                connector_id: tg.connector_id,
+                token: tg.token,
+                require_mention: tg.require_mention,
+            }],
+        });
     }
-
-    match discord {
-        Some(cfg) => {
-            out.push_str("  discord:\n    enabled: true\n    connectors:\n");
-            out.push_str(&format!(
-                "      - connector_id: {}\n        token: \"{}\"\n",
-                cfg.connector_id, cfg.token
-            ));
-            if !cfg.groups.is_empty() {
-                out.push_str("        groups:\n");
-                for g in &cfg.groups {
-                    out.push_str(&format!("          - \"{g}\"\n"));
-                }
-            }
-            if !cfg.require_mention {
-                out.push_str("        require_mention: false\n");
-            }
-        }
-        None => {
-            out.push_str("  discord:\n    enabled: false\n    connectors: []\n");
-        }
+    if let Some(dc) = discord {
+        cfg.channels.discord = Some(DiscordChannelConfig {
+            enabled: true,
+            connectors: vec![DiscordConnectorConfig {
+                connector_id: dc.connector_id,
+                token: dc.token,
+                groups: dc.groups,
+                require_mention: dc.require_mention,
+            }],
+        });
     }
-
-    out.push_str(
-        "\nembedding:\n  enabled: true\n  provider: auto\n  api_key: \"\"\n  model: text-embedding-3-small\n  dimensions: 1536\n  base_url: https://api.openai.com/v1\n\ntools: {}\n",
-    );
-
-    out
+    serde_yaml::to_string(&cfg).expect("failed to serialize MainConfig")
 }
 
 fn generate_routing_yaml(
@@ -1542,8 +1483,9 @@ mod tests {
             }),
         );
 
-        assert!(yaml.contains("token: \"123:telegram-token\""));
-        assert!(yaml.contains("token: \"discord-token\""));
+        // Tokens must appear as plaintext (not env-var references)
+        assert!(yaml.contains("123:telegram-token"));
+        assert!(yaml.contains("discord-token"));
         assert!(!yaml.contains("${"));
     }
 

--- a/crates/clawhive-cli/src/setup_ui.rs
+++ b/crates/clawhive-cli/src/setup_ui.rs
@@ -20,91 +20,80 @@ pub fn print_done(term: &Term, msg: &str) {
     let _ = term.write_line(&format!("{} {}", CHECKMARK, style(msg).green()));
 }
 
+/// Visible width of a string, ignoring ANSI escape codes.
+fn visible_len(s: &str) -> usize {
+    console::measure_text_width(s)
+}
+
+/// Render the setup dashboard as a box-drawing table.
 pub fn render_dashboard(term: &Term, state: &ConfigState) {
-    let _ = term.write_line("");
-    let _ = term.write_line(&format!(
-        "{} {}",
-        CRAB,
-        style("Setup Dashboard").bold().cyan()
-    ));
+    let mut rows: Vec<(&str, String)> = Vec::new();
 
-    let provider_marker = if state.providers.is_empty() {
-        CIRCLE
+    // Providers
+    let providers_val = if state.providers.is_empty() {
+        format!("{CIRCLE} not configured")
     } else {
-        CHECKMARK
+        let parts: Vec<String> = state
+            .providers
+            .iter()
+            .map(|p| {
+                let auth = match &p.auth_summary {
+                    AuthSummary::ApiKey => "api key".to_string(),
+                    AuthSummary::OAuth { profile_name } => format!("oauth ({profile_name})"),
+                };
+                format!("{} ({auth})", style(&p.provider_id).cyan())
+            })
+            .collect();
+        format!("{CHECKMARK}{}", parts.join(", "))
     };
-    let _ = term.write_line(&format!(
-        "\n{} {}",
-        provider_marker,
-        style("Providers").bold()
-    ));
-    if state.providers.is_empty() {
-        let _ = term.write_line("   not configured");
-    } else {
-        for provider in &state.providers {
-            let auth = match &provider.auth_summary {
-                AuthSummary::ApiKey => "api key".to_string(),
-                AuthSummary::OAuth { profile_name } => format!("oauth ({profile_name})"),
-            };
-            let _ = term.write_line(&format!("   - {}: {}", provider.provider_id, auth));
-        }
-    }
+    rows.push(("Providers", providers_val));
 
-    let agent_marker = if state.agents.is_empty() {
-        CIRCLE
+    // Agents
+    let agents_val = if state.agents.is_empty() {
+        format!("{CIRCLE} not configured")
     } else {
-        CHECKMARK
+        let parts: Vec<String> = state
+            .agents
+            .iter()
+            .map(|a| {
+                format!(
+                    "{} {} ({}) {ARROW}{}",
+                    a.emoji,
+                    style(&a.name).cyan(),
+                    a.agent_id,
+                    a.primary_model
+                )
+            })
+            .collect();
+        format!("{CHECKMARK}{}", parts.join(", "))
     };
-    let _ = term.write_line(&format!("\n{} {}", agent_marker, style("Agents").bold()));
-    if state.agents.is_empty() {
-        let _ = term.write_line("   not configured");
-    } else {
-        for agent in &state.agents {
-            let _ = term.write_line(&format!(
-                "   - {} {} ({}) -> {}",
-                agent.emoji, agent.name, agent.agent_id, agent.primary_model
-            ));
-        }
-    }
+    rows.push(("Agents", agents_val));
 
-    let channel_marker = if state.channels.is_empty() {
-        CIRCLE
+    // Channels
+    let channels_val = if state.channels.is_empty() {
+        format!("{CIRCLE} not configured")
     } else {
-        CHECKMARK
+        let parts: Vec<String> = state
+            .channels
+            .iter()
+            .map(|c| format!("{} ({})", style(&c.connector_id).cyan(), c.channel_type))
+            .collect();
+        format!("{CHECKMARK}{}", parts.join(", "))
     };
-    let _ = term.write_line(&format!(
-        "\n{} {}",
-        channel_marker,
-        style("Channels").bold()
-    ));
-    if state.channels.is_empty() {
-        let _ = term.write_line("   not configured");
-    } else {
-        for channel in &state.channels {
-            let _ = term.write_line(&format!(
-                "   - {} ({})",
-                channel.connector_id, channel.channel_type
-            ));
-        }
-    }
+    rows.push(("Channels", channels_val));
 
-    let tools_marker = if state.tools.web_search_enabled {
-        CHECKMARK
-    } else {
-        CIRCLE
-    };
-    let _ = term.write_line(&format!("\n{} {}", tools_marker, style("Tools").bold()));
+    // Tools
+    let mut tool_parts: Vec<String> = Vec::new();
     if state.tools.web_search_enabled {
         let provider = state
             .tools
             .web_search_provider
             .as_deref()
             .unwrap_or("unknown");
-        let _ = term.write_line(&format!("   web_search: on ({provider})"));
+        tool_parts.push(format!("web_search: on ({provider})"));
     } else {
-        let _ = term.write_line("   web_search: off");
+        tool_parts.push("web_search: off".to_string());
     }
-
     let ab_status = if state.tools.actionbook_enabled {
         if state.tools.actionbook_installed {
             "on (installed)"
@@ -114,20 +103,56 @@ pub fn render_dashboard(term: &Term, state: &ConfigState) {
     } else {
         "off"
     };
-    let _ = term.write_line(&format!("   browser_automation: {ab_status}"));
-
-    let routing_marker = if state.default_agent.is_some() {
+    tool_parts.push(format!("browser_automation: {ab_status}"));
+    let tools_marker = if state.tools.web_search_enabled || state.tools.actionbook_enabled {
         CHECKMARK
     } else {
         CIRCLE
     };
-    let _ = term.write_line(&format!("\n{} {}", routing_marker, style("Routing").bold()));
-    match &state.default_agent {
-        Some(agent_id) => {
-            let _ = term.write_line(&format!("   default agent: {agent_id}"));
+    rows.push(("Tools", format!("{tools_marker}{}", tool_parts.join(", "))));
+
+    // Routing
+    let routing_val = match &state.default_agent {
+        Some(agent_id) => format!("{CHECKMARK}default agent: {}", style(agent_id).cyan()),
+        None => format!("{CIRCLE} default agent not configured"),
+    };
+    rows.push(("Routing", routing_val));
+
+    // Render table
+    let label_width = rows.iter().map(|(l, _)| l.len()).max().unwrap_or(0) + 1;
+    let value_width = rows
+        .iter()
+        .map(|(_, v)| visible_len(v))
+        .max()
+        .unwrap_or(0)
+        .max(10);
+
+    let lw = label_width + 2;
+    let vw = value_width + 2;
+
+    let top = format!("┌{}┬{}┐", "─".repeat(lw), "─".repeat(vw));
+    let sep = format!("├{}┼{}┤", "─".repeat(lw), "─".repeat(vw));
+    let bot = format!("└{}┴{}┘", "─".repeat(lw), "─".repeat(vw));
+
+    let title = format!("{CRAB}{}", style("Setup Dashboard").bold().cyan());
+    let _ = term.write_line("");
+    let _ = term.write_line(&format!("  {title}"));
+    let _ = term.write_line(&top);
+
+    for (i, (label, value)) in rows.iter().enumerate() {
+        if i > 0 {
+            let _ = term.write_line(&sep);
         }
-        None => {
-            let _ = term.write_line("   default agent not configured");
-        }
+        let val_visible = visible_len(value);
+        let val_pad = vw.saturating_sub(val_visible + 2);
+        let _ = term.write_line(&format!(
+            "│ {:<width$}│ {}{} │",
+            label,
+            value,
+            " ".repeat(val_pad),
+            width = lw - 1
+        ));
     }
+
+    let _ = term.write_line(&bot);
 }

--- a/crates/clawhive-core/src/config.rs
+++ b/crates/clawhive-core/src/config.rs
@@ -115,9 +115,17 @@ pub struct WebSearchConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ActionbookConfig {
+    #[serde(default)]
+    pub enabled: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ToolsConfig {
     #[serde(default)]
     pub web_search: Option<WebSearchConfig>,
+    #[serde(default)]
+    pub actionbook: Option<ActionbookConfig>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -130,6 +138,32 @@ pub struct MainConfig {
     pub embedding: EmbeddingConfig,
     #[serde(default)]
     pub tools: ToolsConfig,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub web_password_hash: Option<String>,
+}
+
+impl Default for MainConfig {
+    fn default() -> Self {
+        Self {
+            app: AppConfig {
+                name: "clawhive".to_string(),
+            },
+            runtime: RuntimeConfig { max_concurrent: 4 },
+            features: FeaturesConfig {
+                multi_agent: true,
+                sub_agent: true,
+                tui: true,
+                cli: true,
+            },
+            channels: ChannelsConfig {
+                telegram: None,
+                discord: None,
+            },
+            embedding: EmbeddingConfig::default(),
+            tools: ToolsConfig::default(),
+            web_password_hash: None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -778,6 +812,7 @@ mod tests {
                 },
                 embedding: EmbeddingConfig::default(),
                 tools: ToolsConfig::default(),
+                web_password_hash: None,
             },
             routing: RoutingConfig {
                 default_agent_id: "nonexistent".into(),


### PR DESCRIPTION
## Summary
- Add `clawhive config` command to display full configuration with masked tokens (first 4 + last 4 chars visible, middle replaced with `****`)
- Unify `main.yaml` generation: replace string concatenation + raw `serde_yaml::Value` manipulation with typed `MainConfig` serialization via `load_main_config`/`save_main_config` helpers
- Add `Default` for `MainConfig`, add `web_password_hash` and `ActionbookConfig` to typed config structs
- Redesign setup dashboard as box-drawing table matching status output style
- Replace "Reconfigure?" yes/no prompt with Reconfigure/Remove/Cancel select menu (with delete confirmation)
- Fix table right-border alignment off-by-one in both status and setup tables
- Extract `DEFAULT_PORT` constant for the repeated 8848 default port value

## Test plan
- [x] All 823 workspace tests pass
- [x] `cargo fmt` and `cargo clippy` clean
- [x] Pre-commit and pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)