### PR TITLE
feat: add custom OpenAI-compatible provider support

### DIFF
--- a/crates/clawhive-cli/src/commands/setup/agent.rs
+++ b/crates/clawhive-cli/src/commands/setup/agent.rs
@@ -5,9 +5,7 @@ use anyhow::Result;
 use console::Term;
 use dialoguer::{theme::ColorfulTheme, Confirm, Select};
 
-use super::config_io::{
-    format_model_label, input_or_back, input_or_back_with_default, provider_models_for_id,
-};
+use super::config_io::{format_model_label, input_or_back, input_or_back_with_default};
 use super::scan::ConfigState;
 use super::ui::print_done;
 
@@ -64,8 +62,8 @@ pub(super) fn handle_add_agent(
 
     let mut models = Vec::new();
     for p in &state.providers {
-        for m in provider_models_for_id(&p.provider_id) {
-            models.push(m);
+        for m in &p.models {
+            models.push(format!("{}/{}", p.provider_id, m));
         }
     }
     if models.is_empty() {

--- a/crates/clawhive-cli/src/commands/setup/config_io.rs
+++ b/crates/clawhive-cli/src/commands/setup/config_io.rs
@@ -97,10 +97,6 @@ pub(super) fn save_main_config(config_root: &Path, config: &MainConfig) -> Resul
     Ok(())
 }
 
-pub(super) fn provider_models_for_id(provider_id: &str) -> Vec<String> {
-    clawhive_schema::provider_presets::provider_models_for_id(provider_id)
-}
-
 pub(super) fn format_model_label(model_id: &str) -> String {
     let parts: Vec<&str> = model_id.splitn(2, '/').collect();
     if parts.len() == 2 {

--- a/crates/clawhive-cli/src/commands/setup/provider.rs
+++ b/crates/clawhive-cli/src/commands/setup/provider.rs
@@ -35,6 +35,7 @@ pub(super) enum ProviderId {
     MiniMax,
     Volcengine,
     Qianfan,
+    Custom,
 }
 
 pub(super) const ALL_PROVIDERS: &[ProviderId] = &[
@@ -54,6 +55,7 @@ pub(super) const ALL_PROVIDERS: &[ProviderId] = &[
     ProviderId::MiniMax,
     ProviderId::Volcengine,
     ProviderId::Qianfan,
+    ProviderId::Custom,
 ];
 
 impl ProviderId {
@@ -75,6 +77,7 @@ impl ProviderId {
             Self::MiniMax => "minimax",
             Self::Volcengine => "volcengine",
             Self::Qianfan => "qianfan",
+            Self::Custom => "custom",
         }
     }
 
@@ -103,7 +106,7 @@ impl ProviderId {
     }
 
     fn needs_custom_base_url(self) -> bool {
-        matches!(self, Self::AzureOpenAi)
+        matches!(self, Self::AzureOpenAi | Self::Custom)
     }
 }
 
@@ -124,6 +127,12 @@ pub(super) async fn handle_add_provider(
         Some(p) => p,
         None => return Ok(()),
     };
+
+    // Custom providers have a separate flow — they can be added multiple times
+    // with different IDs, so skip the "already configured" check.
+    if provider == ProviderId::Custom {
+        return handle_add_custom_provider(config_root, term, theme).await;
+    }
 
     // For OpenAI we allow separate API-key ("openai") and OAuth ("openai-chatgpt")
     // configs to coexist, so only block when both are already present.
@@ -431,6 +440,73 @@ fn generate_provider_yaml(
     }
 }
 
+async fn handle_add_custom_provider(
+    config_root: &Path,
+    term: &Term,
+    theme: &ColorfulTheme,
+) -> Result<()> {
+    // 1. Ask for a unique provider ID (slug)
+    let custom_id = match input_or_back(theme, "Provider ID (e.g. my-vllm, local-llm)")? {
+        Some(id) if !id.is_empty() => id,
+        Some(_) => anyhow::bail!("Provider ID cannot be empty"),
+        None => return Ok(()),
+    };
+
+    // 2. API base URL (required)
+    let api_base = match input_or_back(theme, "API base URL (e.g. http://localhost:8000/v1)")? {
+        Some(b) if !b.is_empty() => b,
+        Some(_) => anyhow::bail!("API base URL cannot be empty"),
+        None => return Ok(()),
+    };
+
+    // 3. API key (optional — local servers may not need one)
+    let api_key: String = Input::with_theme(theme)
+        .with_prompt("API key (leave empty if not needed)")
+        .allow_empty(true)
+        .interact_text()?;
+
+    // 4. Model name
+    let model = match input_or_back(theme, "Model name (e.g. meta-llama/Llama-3.3-70B-Instruct)")? {
+        Some(m) if !m.is_empty() => m,
+        Some(_) => anyhow::bail!("Model name cannot be empty"),
+        None => return Ok(()),
+    };
+
+    let yaml = generate_custom_provider_yaml(&custom_id, &api_base, &api_key, &model);
+
+    let providers_dir = config_root.join("config/providers.d");
+    fs::create_dir_all(&providers_dir)
+        .with_context(|| format!("failed to create {}", providers_dir.display()))?;
+    let target = providers_dir.join(format!("{custom_id}.yaml"));
+    fs::write(&target, &yaml).with_context(|| format!("failed to write {}", target.display()))?;
+
+    print_done(
+        term,
+        &format!(
+            "Custom provider saved: {}",
+            display_rel(config_root, &target)
+        ),
+    );
+    Ok(())
+}
+
+fn generate_custom_provider_yaml(
+    provider_id: &str,
+    api_base: &str,
+    api_key: &str,
+    model: &str,
+) -> String {
+    if api_key.is_empty() {
+        format!(
+            "provider_id: {provider_id}\nprovider_type: custom\nenabled: true\napi_base: {api_base}\nmodels:\n  - {model}\n",
+        )
+    } else {
+        format!(
+            "provider_id: {provider_id}\nprovider_type: custom\nenabled: true\napi_base: {api_base}\napi_key: \"{api_key}\"\nmodels:\n  - {model}\n",
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::config_io::ensure_required_dirs;
@@ -494,8 +570,11 @@ mod tests {
 
     #[test]
     fn provider_model_aliases_are_fully_qualified() {
-        use super::super::config_io::provider_models_for_id;
+        use clawhive_schema::provider_presets::provider_models_for_id;
         for provider in ALL_PROVIDERS {
+            if *provider == ProviderId::Custom {
+                continue;
+            }
             let models = provider_models_for_id(provider.as_str());
             let prefix = provider.as_str();
             assert!(
@@ -510,8 +589,11 @@ mod tests {
 
     #[test]
     fn provider_models_for_id_returns_known_provider_models() {
-        use super::super::config_io::provider_models_for_id;
+        use clawhive_schema::provider_presets::provider_models_for_id;
         for provider in ALL_PROVIDERS {
+            if *provider == ProviderId::Custom {
+                continue;
+            }
             let models = provider_models_for_id(provider.as_str());
             assert!(
                 !models.is_empty(),
@@ -544,5 +626,41 @@ mod tests {
         let updated = std::fs::read_to_string(&target).expect("read updated provider file");
         assert!(updated.contains("provider_id: openai"));
         assert!(!updated.contains("old: value"));
+    }
+
+    #[test]
+    fn custom_provider_yaml_without_key() {
+        let yaml = generate_custom_provider_yaml(
+            "my-vllm",
+            "http://localhost:8000/v1",
+            "",
+            "meta-llama/Llama-3.3-70B",
+        );
+        assert!(yaml.contains("provider_id: my-vllm"));
+        assert!(yaml.contains("provider_type: custom"));
+        assert!(yaml.contains("api_base: http://localhost:8000/v1"));
+        assert!(yaml.contains("meta-llama/Llama-3.3-70B"));
+        assert!(!yaml.contains("api_key"));
+    }
+
+    #[test]
+    fn custom_provider_yaml_with_key() {
+        let yaml = generate_custom_provider_yaml(
+            "remote-llm",
+            "https://my-server.example.com/v1",
+            "sk-custom-key",
+            "my-model",
+        );
+        assert!(yaml.contains("provider_id: remote-llm"));
+        assert!(yaml.contains("provider_type: custom"));
+        assert!(yaml.contains("api_key: \"sk-custom-key\""));
+        assert!(yaml.contains("my-model"));
+    }
+
+    #[test]
+    fn custom_provider_models_returns_empty() {
+        use clawhive_schema::provider_presets::provider_models_for_id;
+        let models = provider_models_for_id("custom");
+        assert!(models.is_empty());
     }
 }

--- a/crates/clawhive-cli/src/commands/setup/scan.rs
+++ b/crates/clawhive-cli/src/commands/setup/scan.rs
@@ -13,6 +13,7 @@ pub enum AuthSummary {
 pub struct ProviderInfo {
     pub provider_id: String,
     pub auth_summary: AuthSummary,
+    pub models: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -53,6 +54,8 @@ struct RawProviderYaml {
     api_key: Option<String>,
     #[serde(default)]
     auth_profile: Option<String>,
+    #[serde(default)]
+    models: Vec<String>,
 }
 
 pub fn scan_config(root: &Path) -> ConfigState {
@@ -100,6 +103,7 @@ fn scan_providers(config_dir: &Path) -> Vec<ProviderInfo> {
             providers.push(ProviderInfo {
                 provider_id: provider.provider_id,
                 auth_summary,
+                models: provider.models,
             });
         }
     }

--- a/crates/clawhive-cli/src/runtime/bootstrap.rs
+++ b/crates/clawhive-cli/src/runtime/bootstrap.rs
@@ -21,7 +21,7 @@ use clawhive_memory::embedding::{
 };
 use clawhive_memory::MemoryStore;
 use clawhive_provider::{
-    minimax, moonshot, qianfan, qwen, register_builtin_providers, volcengine, zhipu,
+    custom, minimax, moonshot, qianfan, qwen, register_builtin_providers, volcengine, zhipu,
     AnthropicProvider, AzureOpenAiProvider, LlmProvider, LlmRequest, LlmResponse,
     OpenAiChatGptProvider, OpenAiProvider, ProviderRegistry, StreamChunk,
 };
@@ -805,7 +805,21 @@ pub(crate) async fn build_router_from_config(config: &ClawhiveConfig) -> LlmRout
                 }
             }
             _ => {
-                tracing::warn!("Unknown provider: {}", provider_config.provider_id);
+                if provider_config.provider_type.as_deref() == Some("custom") {
+                    let api_key = provider_config
+                        .api_key
+                        .clone()
+                        .filter(|k| !k.is_empty())
+                        .unwrap_or_default();
+                    let provider = Arc::new(custom(api_key, provider_config.api_base.clone()));
+                    registry.register(&provider_config.provider_id, provider);
+                    tracing::info!(
+                        provider_id = %provider_config.provider_id,
+                        "custom OpenAI-compatible provider registered"
+                    );
+                } else {
+                    tracing::warn!("Unknown provider: {}", provider_config.provider_id);
+                }
             }
         }
     }
@@ -1041,6 +1055,7 @@ mod tests {
                     api_base: "https://api.openai.com/v1".to_string(),
                     api_key: None,
                     auth_profile: Some("named-openai".to_string()),
+                    provider_type: None,
                     models: Vec::new(),
                 },
                 ProviderConfig {
@@ -1049,6 +1064,7 @@ mod tests {
                     api_base: "https://chatgpt.com/backend-api/codex".to_string(),
                     api_key: None,
                     auth_profile: None,
+                    provider_type: None,
                     models: Vec::new(),
                 },
                 ProviderConfig {
@@ -1057,6 +1073,7 @@ mod tests {
                     api_base: "https://api.anthropic.com".to_string(),
                     api_key: None,
                     auth_profile: Some("anthropic-session".to_string()),
+                    provider_type: None,
                     models: Vec::new(),
                 },
                 ProviderConfig {
@@ -1065,6 +1082,7 @@ mod tests {
                     api_base: "https://api.openai.com/v1".to_string(),
                     api_key: None,
                     auth_profile: Some("disabled-openai".to_string()),
+                    provider_type: None,
                     models: Vec::new(),
                 },
             ],

--- a/crates/clawhive-core/src/config.rs
+++ b/crates/clawhive-core/src/config.rs
@@ -315,6 +315,8 @@ pub struct ProviderConfig {
     #[serde(default)]
     pub auth_profile: Option<String>,
     #[serde(default)]
+    pub provider_type: Option<String>,
+    #[serde(default)]
     pub models: Vec<String>,
 }
 

--- a/crates/clawhive-provider/src/openai.rs
+++ b/crates/clawhive-provider/src/openai.rs
@@ -15,6 +15,9 @@ pub struct OpenAiProvider {
     api_key: String,
     api_base: String,
     auth_profile: Option<AuthProfile>,
+    /// When true, omit `reasoning_effort` from API requests (for custom
+    /// OpenAI-compatible endpoints that don't support it).
+    strip_reasoning: bool,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -71,7 +74,12 @@ impl OpenAiProvider {
             api_key: api_key.into(),
             api_base: api_base.into().trim_end_matches('/').to_string(),
             auth_profile,
+            strip_reasoning: false,
         }
+    }
+
+    pub fn set_strip_reasoning(&mut self, strip: bool) {
+        self.strip_reasoning = strip;
     }
 
     fn auth_bearer_token(&self) -> &str {
@@ -82,7 +90,11 @@ impl OpenAiProvider {
         }
     }
 
-    pub(crate) fn to_api_request(request: LlmRequest, stream: bool) -> ApiRequest {
+    pub(crate) fn to_api_request(
+        request: LlmRequest,
+        stream: bool,
+        strip_reasoning: bool,
+    ) -> ApiRequest {
         let tools = if request.tools.is_empty() {
             None
         } else {
@@ -102,9 +114,13 @@ impl OpenAiProvider {
             )
         };
 
-        let reasoning_effort = request
-            .thinking_level
-            .map(|level| level.openai_reasoning_effort().to_string());
+        let reasoning_effort = if strip_reasoning {
+            None
+        } else {
+            request
+                .thinking_level
+                .map(|level| level.openai_reasoning_effort().to_string())
+        };
 
         ApiRequest {
             model: request.model,
@@ -128,7 +144,7 @@ impl OpenAiProvider {
 impl LlmProvider for OpenAiProvider {
     async fn chat(&self, request: LlmRequest) -> Result<LlmResponse> {
         let url = format!("{}/chat/completions", self.api_base);
-        let payload = Self::to_api_request(request, false);
+        let payload = Self::to_api_request(request, false, self.strip_reasoning);
 
         let resp = match self
             .client
@@ -170,7 +186,7 @@ impl LlmProvider for OpenAiProvider {
         request: LlmRequest,
     ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamChunk>> + Send>>> {
         let url = format!("{}/chat/completions", self.api_base);
-        let payload = Self::to_api_request(request, true);
+        let payload = Self::to_api_request(request, true, self.strip_reasoning);
 
         let resp = match self
             .client
@@ -714,7 +730,7 @@ mod tests {
             thinking_level: None,
         };
 
-        let api = OpenAiProvider::to_api_request(req, false);
+        let api = OpenAiProvider::to_api_request(req, false, false);
         let json = serde_json::to_value(api).unwrap();
         assert!(json["tools"].is_array());
         assert_eq!(json["messages"][1]["role"], "assistant");
@@ -725,7 +741,7 @@ mod tests {
     #[test]
     fn to_api_request_includes_system_as_first_message() {
         let req = LlmRequest::simple("gpt-4o-mini".into(), Some("be concise".into()), "hi".into());
-        let api = OpenAiProvider::to_api_request(req, false);
+        let api = OpenAiProvider::to_api_request(req, false, false);
         assert_eq!(api.messages[0].role, "system");
         assert_eq!(
             api.messages[0].content,
@@ -844,7 +860,7 @@ mod tests {
             tools: vec![],
             thinking_level: None,
         };
-        let api = OpenAiProvider::to_api_request(req, false);
+        let api = OpenAiProvider::to_api_request(req, false, false);
         assert_eq!(api.messages[0].role, "tool");
         assert_eq!(api.messages[0].tool_call_id.as_deref(), Some("call_1"));
     }
@@ -1020,7 +1036,7 @@ mod tests {
             tools: vec![],
             thinking_level: Some(crate::ThinkingLevel::High),
         };
-        let api_req = OpenAiProvider::to_api_request(req, false);
+        let api_req = OpenAiProvider::to_api_request(req, false, false);
         let json = serde_json::to_value(&api_req).unwrap();
         assert_eq!(json["reasoning_effort"], "high");
     }
@@ -1035,8 +1051,26 @@ mod tests {
             tools: vec![],
             thinking_level: None,
         };
-        let api_req = OpenAiProvider::to_api_request(req, false);
+        let api_req = OpenAiProvider::to_api_request(req, false, false);
         let json = serde_json::to_value(&api_req).unwrap();
         assert!(json.get("reasoning_effort").is_none());
+    }
+
+    #[test]
+    fn to_api_request_strips_reasoning_effort_when_flag_set() {
+        let req = LlmRequest {
+            model: "o4-mini".into(),
+            system: None,
+            messages: vec![LlmMessage::user("test")],
+            max_tokens: 128,
+            tools: vec![],
+            thinking_level: Some(crate::ThinkingLevel::High),
+        };
+        let api_req = OpenAiProvider::to_api_request(req, false, true);
+        let json = serde_json::to_value(&api_req).unwrap();
+        assert!(
+            json.get("reasoning_effort").is_none(),
+            "reasoning_effort should be stripped for custom providers"
+        );
     }
 }

--- a/crates/clawhive-provider/src/openai_compat.rs
+++ b/crates/clawhive-provider/src/openai_compat.rs
@@ -82,9 +82,14 @@ pub fn qianfan(api_key: impl Into<String>) -> OpenAiProvider {
     OpenAiProvider::new(api_key, "https://qianfan.baidubce.com/v2")
 }
 
-/// Custom OpenAI-compatible endpoint
+/// Custom OpenAI-compatible endpoint.
+///
+/// `strip_reasoning` is enabled so that `reasoning_effort` is never sent —
+/// most third-party OpenAI-compatible APIs reject unknown parameters.
 pub fn custom(api_key: impl Into<String>, base_url: impl Into<String>) -> OpenAiProvider {
-    OpenAiProvider::new(api_key, base_url)
+    let mut p = OpenAiProvider::new(api_key, base_url);
+    p.set_strip_reasoning(true);
+    p
 }
 
 #[cfg(test)]

--- a/crates/clawhive-schema/src/provider_presets.rs
+++ b/crates/clawhive-schema/src/provider_presets.rs
@@ -289,6 +289,15 @@ pub const PROVIDER_PRESETS: &[ProviderPreset] = &[
             m("ernie-3.5-8k", 8_192, 4096, false, false),
         ],
     },
+    ProviderPreset {
+        id: "custom",
+        name: "Custom (OpenAI Compatible)",
+        api_base: "",
+        needs_key: false,
+        needs_base_url: true,
+        default_model: "",
+        models: &[],
+    },
 ];
 
 /// Look up a provider preset by id.

--- a/crates/clawhive-server/src/routes/agents.rs
+++ b/crates/clawhive-server/src/routes/agents.rs
@@ -23,9 +23,11 @@ pub struct AgentDetail {
     pub enabled: bool,
     pub identity: AgentIdentity,
     pub model_policy: ModelPolicy,
+    #[serde(default)]
     pub tool_policy: ToolPolicy,
+    #[serde(default)]
     pub memory_policy: MemoryPolicy,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sub_agent: Option<SubAgentPolicy>,
 }
 
@@ -38,18 +40,39 @@ pub struct AgentIdentity {
 #[derive(Serialize, Deserialize)]
 pub struct ModelPolicy {
     pub primary: String,
+    #[serde(default)]
     pub fallbacks: Vec<String>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Default)]
 pub struct ToolPolicy {
+    #[serde(default)]
     pub allow: Vec<String>,
 }
 
 #[derive(Serialize, Deserialize)]
 pub struct MemoryPolicy {
+    #[serde(default = "default_memory_mode")]
     pub mode: String,
+    #[serde(default = "default_memory_write_scope")]
     pub write_scope: String,
+}
+
+impl Default for MemoryPolicy {
+    fn default() -> Self {
+        Self {
+            mode: "standard".to_string(),
+            write_scope: "all".to_string(),
+        }
+    }
+}
+
+fn default_memory_mode() -> String {
+    "standard".to_string()
+}
+
+fn default_memory_write_scope() -> String {
+    "all".to_string()
 }
 
 #[derive(Serialize, Deserialize)]

--- a/crates/clawhive-server/src/routes/providers.rs
+++ b/crates/clawhive-server/src/routes/providers.rs
@@ -33,6 +33,8 @@ pub struct CreateProviderRequest {
     #[serde(default)]
     pub auth_profile: Option<String>,
     #[serde(default)]
+    pub provider_type: Option<String>,
+    #[serde(default)]
     pub models: Vec<String>,
 }
 
@@ -153,6 +155,13 @@ async fn create_provider(
         val.insert(
             serde_yaml::Value::String("auth_profile".to_string()),
             serde_yaml::Value::String(auth_profile),
+        );
+    }
+
+    if let Some(pt) = body.provider_type.filter(|t| !t.trim().is_empty()) {
+        val.insert(
+            serde_yaml::Value::String("provider_type".to_string()),
+            serde_yaml::Value::String(pt),
         );
     }
 
@@ -504,5 +513,33 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), axum::http::StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn create_custom_provider_writes_provider_type() {
+        let (state, _tmp) = setup_state();
+        let app = router().with_state(state.clone());
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"provider_id":"my-vllm","provider_type":"custom","api_base":"http://localhost:8000/v1","models":["llama-3"]}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+
+        let content =
+            std::fs::read_to_string(state.root.join("config/providers.d/my-vllm.yaml")).unwrap();
+        assert!(content.contains("provider_type: custom"));
+        assert!(content.contains("my-vllm"));
+        assert!(content.contains("http://localhost:8000/v1"));
     }
 }

--- a/web/src/hooks/use-api.ts
+++ b/web/src/hooks/use-api.ts
@@ -166,6 +166,7 @@ export interface CreateProviderRequest {
   api_base: string;
   api_key?: string;
   auth_profile?: string;
+  provider_type?: string;
   models: string[];
 }
 

--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -38,7 +38,7 @@ function NewAgentDialog() {
   const { data: providers } = useProviders();
 
   // Collect all models from configured providers
-  const allModels = providers?.flatMap((p) => p.models) ?? [];
+  const allModels = providers?.flatMap((p) => p.models.map((m) => `${p.provider_id}/${m}`)) ?? [];
 
   const reset = () => {
     setAgentId("");
@@ -178,7 +178,7 @@ function AgentDetailDialog({
   const { data: detail, isLoading } = useAgent(agentId);
   const updateAgent = useUpdateAgent();
   const { data: providers } = useProviders();
-  const allModels = providers?.flatMap((p) => p.models) ?? [];
+  const allModels = providers?.flatMap((p) => p.models.map((m) => `${p.provider_id}/${m}`)) ?? [];
 
   const [isEditing, setIsEditing] = useState(false);
   const [editData, setEditData] = useState<AgentDetail | null>(null);

--- a/web/src/pages/Providers.tsx
+++ b/web/src/pages/Providers.tsx
@@ -191,6 +191,8 @@ function AddProviderDialog({ existingIds }: { existingIds: Set<string> }) {
   const [selected, setSelected] = useState<ProviderPreset | null>(null);
   const [apiKey, setApiKey] = useState("");
   const [apiBase, setApiBase] = useState("");
+  const [customProviderId, setCustomProviderId] = useState("");
+  const [customModelInput, setCustomModelInput] = useState("");
   const [selectedModels, setSelectedModels] = useState<Set<string>>(new Set());
   const [customModels, setCustomModels] = useState<string[]>([]);
   const createProvider = useCreateProvider();
@@ -203,6 +205,8 @@ function AddProviderDialog({ existingIds }: { existingIds: Set<string> }) {
   const hasOpenAiOAuth =
     authStatus?.profiles.some((profile) => profile.kind === "OpenAiOAuth") ?? false;
 
+  const isCustom = selected?.id === "custom";
+
   const presetModelIds = (preset: ProviderPreset) =>
     preset.models.map((model) => model.id);
 
@@ -210,6 +214,8 @@ function AddProviderDialog({ existingIds }: { existingIds: Set<string> }) {
     setSelected(null);
     setApiKey("");
     setApiBase("");
+    setCustomProviderId("");
+    setCustomModelInput("");
     setSelectedModels(new Set());
     setCustomModels([]);
   };
@@ -217,8 +223,15 @@ function AddProviderDialog({ existingIds }: { existingIds: Set<string> }) {
   const handleSelect = (p: ProviderPreset) => {
     setSelected(p);
     setApiBase(p.api_base);
-    setSelectedModels(new Set(presetModelIds(p)));
-    setCustomModels([]);
+    if (p.id === "custom") {
+      setSelectedModels(new Set());
+      setCustomModels([]);
+      setCustomProviderId("");
+      setCustomModelInput("");
+    } else {
+      setSelectedModels(new Set(presetModelIds(p)));
+      setCustomModels([]);
+    }
   };
 
   const toggleModel = (model: string) => {
@@ -232,19 +245,33 @@ function AddProviderDialog({ existingIds }: { existingIds: Set<string> }) {
 
   const handleSubmit = async () => {
     if (!selected) return;
-    const modelList = Array.from(selectedModels);
     try {
-      await createProvider.mutateAsync({
-        provider_id: selected.id,
-        api_base: apiBase || selected.api_base,
-        api_key: selected.needs_key ? apiKey || undefined : undefined,
-        auth_profile:
-          selected.id === "openai-chatgpt"
-            ? openAiOAuthProfileName
-            : undefined,
-        models: modelList.length > 0 ? modelList : presetModelIds(selected),
-      });
-      toast.success(`Provider ${selected.name} added`);
+      if (isCustom) {
+        const models = customModelInput.trim()
+          ? [customModelInput.trim()]
+          : [];
+        await createProvider.mutateAsync({
+          provider_id: customProviderId,
+          provider_type: "custom",
+          api_base: apiBase,
+          api_key: apiKey || undefined,
+          models,
+        });
+        toast.success(`Custom provider ${customProviderId} added`);
+      } else {
+        const modelList = Array.from(selectedModels);
+        await createProvider.mutateAsync({
+          provider_id: selected.id,
+          api_base: apiBase || selected.api_base,
+          api_key: selected.needs_key ? apiKey || undefined : undefined,
+          auth_profile:
+            selected.id === "openai-chatgpt"
+              ? openAiOAuthProfileName
+              : undefined,
+          models: modelList.length > 0 ? modelList : presetModelIds(selected),
+        });
+        toast.success(`Provider ${selected.name} added`);
+      }
       reset();
       setOpen(false);
     } catch (e: unknown) {
@@ -256,6 +283,10 @@ function AddProviderDialog({ existingIds }: { existingIds: Set<string> }) {
       }
     }
   };
+
+  const submitDisabled = isCustom
+    ? !customProviderId.trim() || !apiBase.trim() || !customModelInput.trim() || createProvider.isPending
+    : !selected || createProvider.isPending || (selected.needs_key && !apiKey) || (selected.id === "openai-chatgpt" && !hasOpenAiOAuth);
 
   return (
     <Dialog open={open} onOpenChange={(v) => { setOpen(v); if (!v) reset(); }}>
@@ -273,7 +304,7 @@ function AddProviderDialog({ existingIds }: { existingIds: Set<string> }) {
 
         <div className="grid grid-cols-3 gap-2">
           {(presets ?? []).map((p) => {
-            const exists = existingIds.has(p.id);
+            const exists = p.id !== "custom" && existingIds.has(p.id);
             return (
               <button
                 key={p.id}
@@ -294,7 +325,57 @@ function AddProviderDialog({ existingIds }: { existingIds: Set<string> }) {
           })}
         </div>
 
-        {selected && (
+        {selected && isCustom && (
+          <div className="space-y-3 rounded-lg border p-4">
+            <div>
+              <label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                Provider ID
+              </label>
+              <Input
+                placeholder="e.g. my-vllm, local-llm"
+                value={customProviderId}
+                onChange={(e) => setCustomProviderId(e.target.value.replace(/[^a-z0-9-]/g, ""))}
+                className="mt-1 font-mono"
+              />
+            </div>
+            <div>
+              <label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                API Base URL
+              </label>
+              <Input
+                placeholder="e.g. http://localhost:8000/v1"
+                value={apiBase}
+                onChange={(e) => setApiBase(e.target.value)}
+                className="mt-1"
+              />
+            </div>
+            <div>
+              <label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                API Key <span className="normal-case font-normal">(optional)</span>
+              </label>
+              <Input
+                type="password"
+                placeholder="Leave empty if not needed"
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                className="mt-1"
+              />
+            </div>
+            <div>
+              <label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                Model
+              </label>
+              <Input
+                placeholder="e.g. meta-llama/Llama-3.3-70B-Instruct"
+                value={customModelInput}
+                onChange={(e) => setCustomModelInput(e.target.value)}
+                className="mt-1 font-mono"
+              />
+            </div>
+          </div>
+        )}
+
+        {selected && !isCustom && (
           <div className="space-y-3 rounded-lg border p-4">
             {selected.id === "openai-chatgpt" && (
               <OpenAiOAuthSetup />
@@ -344,12 +425,7 @@ function AddProviderDialog({ existingIds }: { existingIds: Set<string> }) {
         <DialogFooter>
           <Button
             onClick={handleSubmit}
-            disabled={
-              !selected ||
-              createProvider.isPending ||
-              (selected.needs_key && !apiKey) ||
-              (selected.id === "openai-chatgpt" && !hasOpenAiOAuth)
-            }
+            disabled={submitDisabled}
           >
             {createProvider.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : "Add Provider"}
           </Button>


### PR DESCRIPTION
## Summary

- Add support for user-defined OpenAI-compatible providers (vLLM, local inference servers, etc.) across CLI wizard, Web UI, and server API
- Custom providers use `provider_type: custom` in YAML config; API key is optional for local servers
- Strip `reasoning_effort` parameter from custom provider API requests (most third-party APIs reject it)
- Fix agent editing bug where missing `tool_policy`/`memory_policy` defaults caused deserialization failure
- Use YAML-configured model list as single source of truth in agent setup (instead of static presets)

## Test Plan

- [x] `just check` passes (fmt + clippy + tests)
- [x] CLI: `clawhive setup` → Add Provider → Custom → enter ID/URL/key/model → YAML generated correctly
- [x] Web UI: Add Provider → Custom card (never disabled) → fill form → provider created
- [x] Runtime: custom provider YAML → `clawhive start` → logs show "custom OpenAI-compatible provider registered"
- [x] Agent config with custom provider model routes correctly without `reasoning_effort` error
- [x] Agent editing works (serde defaults fix)